### PR TITLE
feat(web): design system + full static screens

### DIFF
--- a/apps/web/src/components/MatchBar.jsx
+++ b/apps/web/src/components/MatchBar.jsx
@@ -1,0 +1,36 @@
+/**
+ * MatchBar — horizontal progress bar showing pantry match %.
+ *
+ * Colour thresholds (from saved_and_profile_v2.html):
+ *   ≥ 75 % → green  (--color-match-high-*)
+ *   40–74 % → sage  (--color-match-mid-*)
+ *   < 40 %  → amber (--color-match-low-*)
+ */
+
+function getThreshold(pct) {
+  if (pct >= 75) return 'high';
+  if (pct >= 40) return 'mid';
+  return 'low';
+}
+
+export default function MatchBar({ pct, className = '' }) {
+  const tier = getThreshold(pct);
+
+  return (
+    <div className={`match-bar-wrap ${className}`}>
+      <div className="match-bar-track">
+        <div
+          className={`match-bar-fill match-bar-fill--${tier}`}
+          style={{ width: `${Math.min(pct, 100)}%` }}
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        />
+      </div>
+      <span className={`match-bar-label match-bar-label--${tier}`}>
+        {pct}% in pantry
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/PantryTag.jsx
+++ b/apps/web/src/components/PantryTag.jsx
@@ -1,0 +1,14 @@
+/**
+ * PantryTag — small status pill shown next to recipe ingredients.
+ *
+ * variant="in-pantry" → green  ("In pantry")
+ * variant="missing"   → amber  ("Missing")
+ */
+
+export default function PantryTag({ variant = 'in-pantry', className = '' }) {
+  return (
+    <span className={`pantry-tag pantry-tag--${variant} ${className}`}>
+      {variant === 'in-pantry' ? 'In pantry' : 'Missing'}
+    </span>
+  );
+}

--- a/apps/web/src/components/RecipeCard.jsx
+++ b/apps/web/src/components/RecipeCard.jsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+import MatchBar from './MatchBar.jsx';
+import PantryTag from './PantryTag.jsx';
+
+/**
+ * RecipeCard — collapsed list row that expands into a full detail card.
+ *
+ * Props:
+ *   recipe       object   — recipe data (see fakeData.js for shape)
+ *   actions      array    — [{ label, icon: Component, onClick, variant }]
+ *                           rendered as CTA buttons in expanded state
+ *   defaultExpanded bool  — start expanded (default false)
+ *   showMatchPill bool    — show match pill in collapsed row (Home screen)
+ */
+
+export default function RecipeCard({
+  recipe,
+  actions = [],
+  defaultExpanded = false,
+  showMatchPill = true,
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  if (expanded) {
+    return <ExpandedCard recipe={recipe} actions={actions} onCollapse={() => setExpanded(false)} />;
+  }
+
+  return <CollapsedRow recipe={recipe} onExpand={() => setExpanded(true)} showMatchPill={showMatchPill} />;
+}
+
+// ── Collapsed row ─────────────────────────────────────────────────────────────
+
+function CollapsedRow({ recipe, onExpand, showMatchPill }) {
+  return (
+    <div className="recipe-card__row" onClick={onExpand} role="button" tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && onExpand()}
+      aria-label={`View ${recipe.name}`}
+    >
+      <div className="recipe-card__thumb" aria-hidden="true" />
+      <div className="recipe-card__info">
+        <div className="recipe-card__name">{recipe.name}</div>
+        <div className="recipe-card__meta">
+          <ClockIcon aria-hidden="true" />
+          {recipe.cookTime} min · {recipe.difficulty}
+        </div>
+      </div>
+      {showMatchPill && (
+        <span className="recipe-card__match-pill">{recipe.matchPct}% match</span>
+      )}
+    </div>
+  );
+}
+
+// ── Expanded card ─────────────────────────────────────────────────────────────
+
+function ExpandedCard({ recipe, actions, onCollapse }) {
+  return (
+    <div className="recipe-card--expanded">
+      {/* Header */}
+      <button className="recipe-card__expanded-header" onClick={onCollapse} aria-label="Collapse recipe">
+        <div className="recipe-card__expanded-title">{recipe.name}</div>
+        <div className="recipe-card__expanded-meta">
+          <span><ClockIcon aria-hidden="true" /> {recipe.cookTime} min</span>
+          <span><ChefHatIcon aria-hidden="true" /> {recipe.difficulty}</span>
+          <span><UsersIcon aria-hidden="true" /> {recipe.servings} servings</span>
+        </div>
+      </button>
+
+      {/* Match bar */}
+      <MatchBar pct={recipe.matchPct} className="recipe-card__match-bar" />
+
+      {/* Body */}
+      <div className="recipe-card__expanded-body">
+        {/* Ingredients */}
+        <p className="section-label">Ingredients</p>
+        <div className="recipe-card__ing-list">
+          {recipe.ingredients.map((ing, i) => (
+            <div key={i} className="recipe-card__ing-row">
+              <div className="recipe-card__ing-left">
+                {ing.inPantry
+                  ? <CheckCircleIcon className="icon--green" aria-hidden="true" />
+                  : <AlertCircleIcon className="icon--amber" aria-hidden="true" />}
+                {ing.name}
+              </div>
+              <div className="recipe-card__ing-right">
+                <span className="recipe-card__ing-qty">{ing.quantity} {ing.unit}</span>
+                <PantryTag variant={ing.inPantry ? 'in-pantry' : 'missing'} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Steps */}
+        <p className="section-label">Steps</p>
+        <div className="recipe-card__steps">
+          {recipe.steps.map((step, i) => (
+            <div key={i} className="recipe-card__step-row">
+              <div className="recipe-card__step-num" aria-hidden="true">{i + 1}</div>
+              <p className="recipe-card__step-text">{step}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* CTA buttons */}
+        {actions.length > 0 && (
+          <div className="recipe-card__cta-row">
+            {actions.map(({ label, icon: Icon, onClick, variant = 'primary' }, i) => (
+              <button
+                key={i}
+                className={`btn btn--${variant} recipe-card__cta-btn`}
+                onClick={onClick}
+              >
+                {Icon && <Icon aria-hidden="true" />}
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Inline icons ─────────────────────────────────────────────────────────────
+
+function ClockIcon(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+    </svg>
+  );
+}
+function ChefHatIcon(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" /><line x1="6" y1="17" x2="18" y2="17" />
+    </svg>
+  );
+}
+function UsersIcon(props) {
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+function CheckCircleIcon({ className, ...props }) {
+  return (
+    <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+function AlertCircleIcon({ className, ...props }) {
+  return (
+    <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+// Export icon helpers so pages can use them in action arrays
+export { ChefHatIcon, CheckCircleIcon };

--- a/apps/web/src/components/TabBar.jsx
+++ b/apps/web/src/components/TabBar.jsx
@@ -1,50 +1,37 @@
 import { NavLink, useLocation } from 'react-router-dom';
+import useAuthStore from '../stores/authStore.js';
 
 /**
- * TabBar — persistent bottom navigation for the five main tabs.
+ * TabBar — persistent bottom navigation.
  *
- * Hidden on the /auth route so the sign-in page gets a full-bleed layout.
- * Active tab is highlighted via NavLink's `isActive` flag + CSS class.
+ * Auth-aware:
+ *  - When the user is signed in, the 5th tab shows "Profile".
+ *  - When signed out, it shows "Sign in" and links to /auth.
+ *
+ * Hidden entirely on /auth (full-screen layout).
  */
-
-const TABS = [
-  {
-    to: '/',
-    end: true, // exact match — don't activate for /chef, /pantry, etc.
-    label: 'Home',
-    icon: HomeIcon,
-  },
-  {
-    to: '/chef',
-    label: 'Chef',
-    icon: ChefIcon,
-  },
-  {
-    to: '/pantry',
-    label: 'Pantry',
-    icon: PantryIcon,
-  },
-  {
-    to: '/saved',
-    label: 'Saved',
-    icon: SavedIcon,
-  },
-  {
-    to: '/profile',
-    label: 'Profile',
-    icon: ProfileIcon,
-  },
-];
 
 export default function TabBar() {
   const { pathname } = useLocation();
+  const { user } = useAuthStore();
 
-  // Don't render the tab bar on the auth screen
   if (pathname === '/auth') return null;
+
+  const tabs = [
+    { to: '/',        end: true,  label: 'Home',    icon: HomeIcon },
+    { to: '/chef',              label: 'Chef',    icon: SparklesIcon },
+    { to: '/pantry',            label: 'Pantry',  icon: BasketIcon },
+    { to: '/saved',             label: 'Saved',   icon: BookmarkIcon },
+    {
+      to: user ? '/profile' : '/auth',
+      label: user ? 'Profile' : 'Sign in',
+      icon: user ? ProfileIcon : SignInIcon,
+    },
+  ];
 
   return (
     <nav className="tab-bar" aria-label="Main navigation">
-      {TABS.map(({ to, end, label, icon: Icon }) => (
+      {tabs.map(({ to, end, label, icon: Icon }) => (
         <NavLink
           key={to}
           to={to}
@@ -62,9 +49,7 @@ export default function TabBar() {
   );
 }
 
-// ── Inline SVG icons ──────────────────────────────────────────────────────────
-// Kept inline so there's no icon-library dependency. Swap for your icon set
-// (Lucide, Heroicons, etc.) when the design is finalised.
+// ── Icons ──────────────────────────────────────────────────────────────────────
 
 function HomeIcon({ className }) {
   return (
@@ -75,16 +60,17 @@ function HomeIcon({ className }) {
   );
 }
 
-function ChefIcon({ className }) {
+function SparklesIcon({ className }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
-      <path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" />
-      <line x1="6" y1="17" x2="18" y2="17" />
+      <path d="M12 3 L13.5 8.5 L19 10 L13.5 11.5 L12 17 L10.5 11.5 L5 10 L10.5 8.5 Z" />
+      <path d="M5 3 L5.8 5.2 L8 6 L5.8 6.8 L5 9 L4.2 6.8 L2 6 L4.2 5.2 Z" />
+      <path d="M19 17 L19.6 18.8 L21 19 L19.6 19.6 L19 21 L18.4 19.6 L17 19 L18.4 18.4 Z" />
     </svg>
   );
 }
 
-function PantryIcon({ className }) {
+function BasketIcon({ className }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
       <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
@@ -94,7 +80,7 @@ function PantryIcon({ className }) {
   );
 }
 
-function SavedIcon({ className }) {
+function BookmarkIcon({ className }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
       <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16Z" />
@@ -107,6 +93,16 @@ function ProfileIcon({ className }) {
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
       <circle cx="12" cy="8" r="4" />
       <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+    </svg>
+  );
+}
+
+function SignInIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      <polyline points="10 17 15 12 10 7" />
+      <line x1="15" y1="12" x2="3" y2="12" />
     </svg>
   );
 }

--- a/apps/web/src/components/Toast.jsx
+++ b/apps/web/src/components/Toast.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Toast — auto-dismissing notification bar.
+ *
+ * Props:
+ *   message  string        — text to display
+ *   visible  boolean       — controlled visibility
+ *   onDismiss () => void   — called when the toast disappears
+ *   duration number        — ms before auto-dismiss (default 3000)
+ *   variant  'default'|'success' — 'success' shows green checkmark icon
+ */
+
+export default function Toast({
+  message,
+  visible,
+  onDismiss,
+  duration = 3000,
+  variant = 'success',
+}) {
+  const [show, setShow] = useState(visible);
+
+  useEffect(() => {
+    setShow(visible);
+    if (!visible) return;
+    const t = setTimeout(() => {
+      setShow(false);
+      onDismiss?.();
+    }, duration);
+    return () => clearTimeout(t);
+  }, [visible, duration, onDismiss]);
+
+  if (!show) return null;
+
+  return (
+    <div className="toast" role="status" aria-live="polite">
+      {variant === 'success' && (
+        <CheckIcon className="toast__icon" aria-hidden="true" />
+      )}
+      <span className="toast__message">{message}</span>
+    </div>
+  );
+}
+
+function CheckIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}

--- a/apps/web/src/data/fakeData.js
+++ b/apps/web/src/data/fakeData.js
@@ -1,0 +1,210 @@
+/**
+ * fakeData.js — static fixture data used by all static screens.
+ * Replace with React Query hooks when the API is wired up.
+ */
+
+export const FAKE_USER = {
+  displayName: 'Jamie Moreau',
+  email: 'jamie@example.com',
+  roleLabel: 'Home cook',
+  city: 'Montréal',
+  avatarUrl: null,
+};
+
+export const FAKE_STATS = {
+  pantryCount: 14,
+  savedCount: 8,
+  cookedCount: 23,
+};
+
+// ── Ingredients catalogue (used by Pantry autosuggest) ────────────────────
+export const INGREDIENT_CATALOGUE = [
+  { id: '1',  name: 'Chicken breast',  category: 'Protein',  defaultUnit: 'g' },
+  { id: '2',  name: 'Chickpeas',       category: 'Legumes',  defaultUnit: 'g' },
+  { id: '3',  name: 'Chicken thighs',  category: 'Protein',  defaultUnit: 'g' },
+  { id: '4',  name: 'Tomatoes',        category: 'Produce',  defaultUnit: 'pcs' },
+  { id: '5',  name: 'Spinach',         category: 'Produce',  defaultUnit: 'g' },
+  { id: '6',  name: 'Garlic',          category: 'Produce',  defaultUnit: 'cloves' },
+  { id: '7',  name: 'Onion',           category: 'Produce',  defaultUnit: 'pcs' },
+  { id: '8',  name: 'Eggs',            category: 'Dairy',    defaultUnit: 'pcs' },
+  { id: '9',  name: 'Feta cheese',     category: 'Dairy',    defaultUnit: 'g' },
+  { id: '10', name: 'Milk',            category: 'Dairy',    defaultUnit: 'ml' },
+  { id: '11', name: 'Rice',            category: 'Grains',   defaultUnit: 'g' },
+  { id: '12', name: 'Pasta',           category: 'Grains',   defaultUnit: 'g' },
+  { id: '13', name: 'Olive oil',       category: 'Other',    defaultUnit: 'ml' },
+  { id: '14', name: 'Cumin',           category: 'Other',    defaultUnit: 'tsp' },
+  { id: '15', name: 'Avocado',         category: 'Produce',  defaultUnit: 'pcs' },
+  { id: '16', name: 'Lemon',           category: 'Produce',  defaultUnit: 'pcs' },
+  { id: '17', name: 'Bell pepper',     category: 'Produce',  defaultUnit: 'pcs' },
+  { id: '18', name: 'Broccoli',        category: 'Produce',  defaultUnit: 'g' },
+  { id: '19', name: 'Salmon fillet',   category: 'Protein',  defaultUnit: 'g' },
+  { id: '20', name: 'Greek yogurt',    category: 'Dairy',    defaultUnit: 'g' },
+];
+
+// ── Pantry items (by category) ─────────────────────────────────────────────
+export const FAKE_PANTRY = {
+  Produce: [
+    { id: 'p1', name: 'Tomatoes', quantity: 3,   unit: 'pcs' },
+    { id: 'p2', name: 'Spinach',  quantity: 100, unit: 'g' },
+    { id: 'p3', name: 'Garlic',   quantity: 6,   unit: 'cloves' },
+    { id: 'p4', name: 'Onion',    quantity: 2,   unit: 'pcs' },
+  ],
+  Dairy: [
+    { id: 'p5', name: 'Eggs', quantity: 6,   unit: 'pcs' },
+    { id: 'p6', name: 'Feta', quantity: 200, unit: 'g' },
+  ],
+  Grains: [
+    { id: 'p7', name: 'Pasta', quantity: 400, unit: 'g' },
+    { id: 'p8', name: 'Rice',  quantity: 800, unit: 'g' },
+  ],
+  Protein: [
+    { id: 'p9',  name: 'Chicken breast', quantity: 500, unit: 'g' },
+    { id: 'p10', name: 'Salmon fillet',  quantity: 300, unit: 'g' },
+  ],
+  Other: [
+    { id: 'p11', name: 'Olive oil', quantity: 500, unit: 'ml' },
+    { id: 'p12', name: 'Cumin',     quantity: 30,  unit: 'g' },
+    { id: 'p13', name: 'Lemon',     quantity: 3,   unit: 'pcs' },
+    { id: 'p14', name: 'Avocado',   quantity: 2,   unit: 'pcs' },
+  ],
+};
+
+// ── Recipes ────────────────────────────────────────────────────────────────
+const SHAKSHUKA = {
+  id: 'r1',
+  name: 'Spiced Tomato & Feta Shakshuka',
+  cookTime: 30,
+  difficulty: 'Easy',
+  servings: 2,
+  cuisine: 'Mediterranean',
+  mealType: 'Dinner',
+  matchPct: 94,
+  isChefPick: true,
+  ingredients: [
+    { name: 'Tomatoes',    quantity: 3,  unit: 'pcs',   inPantry: true },
+    { name: 'Eggs',        quantity: 4,  unit: 'pcs',   inPantry: true },
+    { name: 'Feta cheese', quantity: 80, unit: 'g',     inPantry: true },
+    { name: 'Garlic',      quantity: 2,  unit: 'cloves',inPantry: true },
+    { name: 'Cumin',       quantity: 1,  unit: 'tsp',   inPantry: false },
+  ],
+  steps: [
+    'Heat olive oil in a pan over medium heat. Sauté garlic and onion until soft, about 4 minutes.',
+    'Add crushed tomatoes and spices. Simmer for 10 minutes until thickened.',
+    'Create wells in the sauce and crack eggs in. Cover and cook 5–7 min.',
+    'Crumble feta on top and serve straight from the pan.',
+  ],
+};
+
+const PASTA = {
+  id: 'r2',
+  name: 'Pasta Aglio e Olio',
+  cookTime: 15,
+  difficulty: 'Easy',
+  servings: 2,
+  cuisine: 'Italian',
+  mealType: 'Lunch',
+  matchPct: 87,
+  isChefPick: true,
+  ingredients: [
+    { name: 'Pasta',      quantity: 200, unit: 'g',      inPantry: true },
+    { name: 'Garlic',     quantity: 4,   unit: 'cloves', inPantry: true },
+    { name: 'Olive oil',  quantity: 60,  unit: 'ml',     inPantry: true },
+    { name: 'Parsley',    quantity: 1,   unit: 'bunch',  inPantry: false },
+    { name: 'Chilli',     quantity: 1,   unit: 'pcs',    inPantry: false },
+  ],
+  steps: [
+    'Boil salted water. Cook pasta until al dente.',
+    'Gently fry sliced garlic in olive oil until golden.',
+    'Drain pasta, toss in garlic oil with chilli flakes.',
+    'Finish with chopped parsley and a squeeze of lemon.',
+  ],
+};
+
+const STIR_FRY = {
+  id: 'r3',
+  name: 'Veggie Stir Fry',
+  cookTime: 20,
+  difficulty: 'Medium',
+  servings: 2,
+  cuisine: 'Asian',
+  mealType: 'Dinner',
+  matchPct: 80,
+  isChefPick: false,
+  ingredients: [
+    { name: 'Bell pepper', quantity: 2,   unit: 'pcs', inPantry: true },
+    { name: 'Broccoli',    quantity: 200, unit: 'g',   inPantry: true },
+    { name: 'Rice',        quantity: 200, unit: 'g',   inPantry: true },
+    { name: 'Soy sauce',   quantity: 3,   unit: 'tbsp',inPantry: false },
+    { name: 'Ginger',      quantity: 1,   unit: 'tsp', inPantry: false },
+  ],
+  steps: [
+    'Cook rice as per package instructions.',
+    'Heat wok until smoking. Add oil.',
+    'Stir fry vegetables on high heat for 3–4 min.',
+    'Add soy sauce and ginger. Toss to combine.',
+    'Serve over rice.',
+  ],
+};
+
+const AVOCADO_TOAST = {
+  id: 'r4',
+  name: 'Avocado & Poached Egg Toast',
+  cookTime: 10,
+  difficulty: 'Easy',
+  servings: 1,
+  cuisine: 'Modern',
+  mealType: 'Breakfast',
+  matchPct: 60,
+  isChefPick: false,
+  ingredients: [
+    { name: 'Avocado',      quantity: 1, unit: 'pcs',   inPantry: true },
+    { name: 'Eggs',         quantity: 2, unit: 'pcs',   inPantry: true },
+    { name: 'Sourdough',    quantity: 2, unit: 'slices',inPantry: false },
+    { name: 'Chilli flakes',quantity: 1, unit: 'tsp',   inPantry: false },
+    { name: 'Lemon',        quantity: 1, unit: 'pcs',   inPantry: true },
+  ],
+  steps: [
+    'Toast sourdough until golden.',
+    'Poach eggs in simmering water for 3 min.',
+    'Smash avocado with lemon juice, salt and pepper.',
+    'Spread avocado on toast, top with egg and chilli flakes.',
+  ],
+};
+
+const LEMON_PASTA = {
+  id: 'r5',
+  name: 'Lemon Garlic Pasta',
+  cookTime: 20,
+  difficulty: 'Easy',
+  servings: 2,
+  cuisine: 'Italian',
+  mealType: 'Lunch',
+  matchPct: 40,
+  isChefPick: true,
+  ingredients: [
+    { name: 'Pasta',         quantity: 200, unit: 'g',      inPantry: true },
+    { name: 'Lemon',         quantity: 1,   unit: 'pcs',    inPantry: true },
+    { name: 'Garlic',        quantity: 3,   unit: 'cloves', inPantry: true },
+    { name: 'Parmesan',      quantity: 50,  unit: 'g',      inPantry: false },
+    { name: 'Heavy cream',   quantity: 100, unit: 'ml',     inPantry: false },
+    { name: 'Fresh basil',   quantity: 1,   unit: 'bunch',  inPantry: false },
+  ],
+  steps: [
+    'Cook pasta al dente. Reserve 1 cup pasta water.',
+    'Sauté garlic in butter until fragrant.',
+    'Add cream and lemon juice. Simmer 2 min.',
+    'Toss pasta in sauce, add parmesan. Adjust with pasta water.',
+    'Top with fresh basil.',
+  ],
+};
+
+export const FAKE_SUGGESTIONS = [SHAKSHUKA, PASTA, STIR_FRY];
+
+export const FAKE_SAVED = [SHAKSHUKA, AVOCADO_TOAST, LEMON_PASTA];
+
+// Chef screen result
+export const FAKE_CHEF_RESULT = {
+  ...SHAKSHUKA,
+  name: 'Spiced Tomato & Feta Shakshuka',
+  missingCount: 1,
+};

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -4,7 +4,8 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import App from './App.jsx';
-import './index.css';
+import './styles/tokens.css';
+import './styles/components.css';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/web/src/pages/Auth.jsx
+++ b/apps/web/src/pages/Auth.jsx
@@ -1,5 +1,209 @@
-// TODO: Firebase sign-in UI (Google OAuth + email/password)
-// On success call POST /api/v1/auth/sync then redirect to /
-export default function Auth() {
-  return <div className="page">Auth — sign-in placeholder</div>;
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Auth — sign-in / create account, full-screen layout (no tab bar).
+ *
+ * Modes:  'signin' | 'signup'
+ * Validation: client-side only — no API calls yet.
+ *   - Email must be valid format
+ *   - Password ≥ 8 characters
+ *   - Confirm password must match (signup only)
+ */
+
+function validate(mode, { email, password, confirmPassword }) {
+  const errors = {};
+  if (!email) {
+    errors.email = 'Email is required.';
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.email = 'Please enter a valid email address.';
+  }
+  if (!password) {
+    errors.password = 'Password is required.';
+  } else if (password.length < 8) {
+    errors.password = 'Password must be at least 8 characters.';
+  }
+  if (mode === 'signup') {
+    if (!confirmPassword) {
+      errors.confirmPassword = 'Please confirm your password.';
+    } else if (confirmPassword !== password) {
+      errors.confirmPassword = 'Passwords do not match.';
+    }
+  }
+  return errors;
 }
+
+export default function Auth() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState('signin'); // 'signin' | 'signup'
+  const [fields, setFields] = useState({ email: '', password: '', confirmPassword: '' });
+  const [errors, setErrors] = useState({});
+  const [showPassword, setShowPassword] = useState(false);
+
+  function setField(key, val) {
+    setFields(f => ({ ...f, [key]: val }));
+    // Clear error on edit
+    if (errors[key]) setErrors(e => { const n = { ...e }; delete n[key]; return n; });
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    const errs = validate(mode, fields);
+    if (Object.keys(errs).length) {
+      setErrors(errs);
+      return;
+    }
+    // TODO: call Firebase signInWithEmailAndPassword / createUserWithEmailAndPassword
+    // then POST /api/v1/auth/sync → navigate('/')
+    alert(`[Auth stub] ${mode === 'signin' ? 'Sign in' : 'Create account'} with ${fields.email}`);
+  }
+
+  function handleGoogle() {
+    // TODO: call Firebase signInWithPopup(googleProvider)
+    alert('[Auth stub] Continue with Google');
+  }
+
+  function toggleMode() {
+    setMode(m => m === 'signin' ? 'signup' : 'signin');
+    setErrors({});
+    setFields({ email: '', password: '', confirmPassword: '' });
+  }
+
+  return (
+    <div className="auth-screen">
+      {/* Logo / wordmark */}
+      <div className="auth-logo" aria-label="Plated">
+        <PlatedLogo />
+        <span className="auth-logo__name">Plated</span>
+      </div>
+
+      <div className="auth-card">
+        <h2 className="auth-card__title">
+          {mode === 'signin' ? 'Welcome back' : 'Create your account'}
+        </h2>
+        <p className="auth-card__sub">
+          {mode === 'signin'
+            ? 'Sign in to see what you can cook today.'
+            : 'Track your pantry and get AI-powered recipes.'}
+        </p>
+
+        {/* Google SSO */}
+        <button className="btn-google" onClick={handleGoogle}>
+          <GoogleIcon aria-hidden="true" />
+          Continue with Google
+        </button>
+
+        {/* Divider */}
+        <div className="auth-divider">
+          <div className="auth-divider__line" />
+          <span className="auth-divider__label">or</span>
+          <div className="auth-divider__line" />
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} noValidate>
+          {/* Email */}
+          <div className="form-field">
+            <label className="form-label" htmlFor="auth-email">Email</label>
+            <input
+              id="auth-email"
+              type="email"
+              className={`auth-input ${errors.email ? 'auth-input--error' : ''}`}
+              placeholder="you@example.com"
+              value={fields.email}
+              onChange={e => setField('email', e.target.value)}
+              autoComplete="email"
+              inputMode="email"
+            />
+            {errors.email && <p className="field-error">{errors.email}</p>}
+          </div>
+
+          {/* Password */}
+          <div className="form-field">
+            <label className="form-label" htmlFor="auth-password">Password</label>
+            <div className="auth-input-wrap">
+              <input
+                id="auth-password"
+                type={showPassword ? 'text' : 'password'}
+                className={`auth-input auth-input--with-toggle ${errors.password ? 'auth-input--error' : ''}`}
+                placeholder="Min. 8 characters"
+                value={fields.password}
+                onChange={e => setField('password', e.target.value)}
+                autoComplete={mode === 'signin' ? 'current-password' : 'new-password'}
+              />
+              <button
+                type="button"
+                className="auth-input__toggle"
+                onClick={() => setShowPassword(v => !v)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? <EyeOffIcon aria-hidden="true" /> : <EyeIcon aria-hidden="true" />}
+              </button>
+            </div>
+            {errors.password && <p className="field-error">{errors.password}</p>}
+          </div>
+
+          {/* Confirm password (signup only) */}
+          {mode === 'signup' && (
+            <div className="form-field">
+              <label className="form-label" htmlFor="auth-confirm">Confirm password</label>
+              <input
+                id="auth-confirm"
+                type="password"
+                className={`auth-input ${errors.confirmPassword ? 'auth-input--error' : ''}`}
+                placeholder="Repeat your password"
+                value={fields.confirmPassword}
+                onChange={e => setField('confirmPassword', e.target.value)}
+                autoComplete="new-password"
+              />
+              {errors.confirmPassword && <p className="field-error">{errors.confirmPassword}</p>}
+            </div>
+          )}
+
+          <button type="submit" className="btn btn--primary btn--large btn--full" style={{ marginTop: 8 }}>
+            {mode === 'signin' ? 'Sign in' : 'Create account'}
+          </button>
+        </form>
+
+        {/* Mode toggle */}
+        <p className="auth-toggle">
+          {mode === 'signin' ? "Don't have an account?" : 'Already have an account?'}{' '}
+          <button className="auth-toggle__btn" onClick={toggleMode}>
+            {mode === 'signin' ? 'Create one' : 'Sign in'}
+          </button>
+        </p>
+      </div>
+
+      {/* Maybe later (back to app without auth) */}
+      <button className="auth-skip" onClick={() => navigate('/')}>
+        Maybe later
+      </button>
+    </div>
+  );
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function PlatedLogo() {
+  return (
+    <svg width="32" height="32" viewBox="0 0 32 32" fill="none">
+      <circle cx="16" cy="16" r="16" fill="var(--color-primary)" />
+      <path d="M16 8c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 14c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z" fill="white" />
+      <path d="M16 13a3 3 0 1 0 0 6 3 3 0 0 0 0-6z" fill="white" />
+    </svg>
+  );
+}
+
+function GoogleIcon(props) {
+  return (
+    <svg {...props} width="18" height="18" viewBox="0 0 18 18">
+      <path fill="#4285F4" d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" />
+      <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" />
+      <path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" />
+      <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" />
+    </svg>
+  );
+}
+
+function EyeIcon(props)    { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="12" r="3" /></svg>; }
+function EyeOffIcon(props) { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" /><line x1="1" y1="1" x2="23" y2="23" /></svg>; }

--- a/apps/web/src/pages/Chef.jsx
+++ b/apps/web/src/pages/Chef.jsx
@@ -1,4 +1,324 @@
-// TODO: implement AI Chef chat UI (text + voice input, message history)
+import { useState } from 'react';
+import PantryTag from '../components/PantryTag.jsx';
+import Toast from '../components/Toast.jsx';
+import { FAKE_CHEF_RESULT, FAKE_STATS } from '../data/fakeData.js';
+
+/**
+ * Chef — three states from chef_wireframes.html:
+ *   'input'      → filter chips, servings stepper, notes, "Chef it" button
+ *   'generating' → spinner + loading copy
+ *   'result'     → recipe detail + missing banner + Approve / Retry buttons
+ */
+
+const MEAL_TYPES  = ['Breakfast', 'Lunch', 'Dinner', 'Snack'];
+const COOK_TIMES  = ['Under 15 min', '30 min', '1 hr+'];
+const DIFFICULTIES = ['Easy', 'Medium', 'Hard'];
+const CUISINES = [
+  '', 'Italian', 'Mediterranean', 'Asian', 'Mexican', 'French', 'Indian', 'Middle Eastern',
+];
+
 export default function Chef() {
-  return <div className="page">Chef — AI chat placeholder</div>;
+  const [view, setView] = useState('input'); // 'input' | 'generating' | 'result'
+
+  const [filters, setFilters] = useState({
+    mealType: 'Lunch',
+    cookTime: '30 min',
+    difficulty: 'Easy',
+    cuisine: '',
+    servings: 2,
+    notes: '',
+  });
+  const [toastVisible, setToastVisible] = useState(false);
+
+  function setFilter(key, val) {
+    setFilters(f => ({ ...f, [key]: val }));
+  }
+
+  function handleChefIt() {
+    setView('generating');
+    // Simulate API latency (remove when real endpoint is wired)
+    setTimeout(() => setView('result'), 1800);
+  }
+
+  function handleApprove() {
+    setToastVisible(true);
+    setView('input');
+  }
+
+  function handleRetry() {
+    setView('generating');
+    setTimeout(() => setView('result'), 1800);
+  }
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <h1 className="page-title">
+          Chef <span className="ai-badge">AI</span>
+        </h1>
+        {view === 'result' && (
+          <button className="text-btn text-btn--primary" onClick={() => setView('input')}>
+            <AdjustIcon aria-hidden="true" /> Adjust
+          </button>
+        )}
+      </div>
+
+      <Toast
+        message="Recipe approved and saved to your collection!"
+        visible={toastVisible}
+        onDismiss={() => setToastVisible(false)}
+      />
+
+      {view === 'input' && (
+        <InputState filters={filters} setFilter={setFilter} onSubmit={handleChefIt} />
+      )}
+      {view === 'generating' && <GeneratingState />}
+      {view === 'result' && (
+        <ResultState recipe={FAKE_CHEF_RESULT} onApprove={handleApprove} onRetry={handleRetry} />
+      )}
+
+      <div className="page-bottom" />
+    </div>
+  );
+}
+
+// ── Input state ───────────────────────────────────────────────────────────────
+
+function InputState({ filters, setFilter, onSubmit }) {
+  return (
+    <>
+      <div className="pantry-note">
+        <BasketIcon aria-hidden="true" />
+        <span>Using {FAKE_STATS.pantryCount} pantry items to generate your recipe</span>
+      </div>
+
+      <ChipGroup
+        label="Meal type"
+        options={MEAL_TYPES}
+        value={filters.mealType}
+        onChange={v => setFilter('mealType', v)}
+      />
+
+      <ChipGroup
+        label="Cook time"
+        options={COOK_TIMES}
+        value={filters.cookTime}
+        onChange={v => setFilter('cookTime', v)}
+      />
+
+      <ChipGroup
+        label="Difficulty"
+        options={DIFFICULTIES}
+        value={filters.difficulty}
+        onChange={v => setFilter('difficulty', v)}
+      />
+
+      <div>
+        <p className="section-label">
+          Cuisine <span className="section-label-optional">— optional</span>
+        </p>
+        <select
+          className="form-select"
+          value={filters.cuisine}
+          onChange={e => setFilter('cuisine', e.target.value)}
+          aria-label="Cuisine"
+        >
+          {CUISINES.map(c => (
+            <option key={c} value={c}>{c || 'Select a cuisine…'}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="divider" />
+
+      {/* Servings stepper */}
+      <div className="card card--row">
+        <div>
+          <div className="card__title">Servings</div>
+          <div className="card__subtitle">How many plates?</div>
+        </div>
+        <div className="stepper">
+          <button
+            className="stepper__btn"
+            aria-label="Decrease servings"
+            onClick={() => setFilter('servings', Math.max(1, filters.servings - 1))}
+          >−</button>
+          <span className="stepper__val">{filters.servings}</span>
+          <button
+            className="stepper__btn"
+            aria-label="Increase servings"
+            onClick={() => setFilter('servings', Math.min(12, filters.servings + 1))}
+          >+</button>
+        </div>
+      </div>
+
+      <div>
+        <p className="section-label">
+          Extra notes <span className="section-label-optional">— optional</span>
+        </p>
+        <textarea
+          className="notes-field"
+          placeholder="e.g. make it spicy, no cilantro, high protein…"
+          value={filters.notes}
+          onChange={e => setFilter('notes', e.target.value)}
+          rows={3}
+          aria-label="Extra notes for Chef"
+        />
+        <p className="form-hint">Chef will figure out the rest</p>
+      </div>
+
+      <button className="btn btn--primary btn--large btn--full" onClick={onSubmit}>
+        <SparklesIcon aria-hidden="true" /> Chef it
+      </button>
+    </>
+  );
+}
+
+// ── Generating state ──────────────────────────────────────────────────────────
+
+function GeneratingState() {
+  return (
+    <div className="generating-state">
+      <div className="spinner" aria-label="Generating recipe…" role="status" />
+      <p className="generating-state__title">Chef is cooking…</p>
+      <p className="generating-state__sub">Finding the best recipe from your pantry</p>
+    </div>
+  );
+}
+
+// ── Result state ──────────────────────────────────────────────────────────────
+
+function ResultState({ recipe, onApprove, onRetry }) {
+  const missing = recipe.ingredients.filter(i => !i.inPantry);
+
+  return (
+    <>
+      {/* Recipe header */}
+      <div className="result-header">
+        <div className="result-header__title">{recipe.name}</div>
+        <div className="result-header__meta">
+          <span><ClockIcon aria-hidden="true" /> {recipe.cookTime} min</span>
+          <span><ChefHatIcon aria-hidden="true" /> {recipe.difficulty}</span>
+          <span><UsersIcon aria-hidden="true" /> {recipe.servings} servings</span>
+        </div>
+      </div>
+
+      {/* Missing ingredients banner */}
+      {missing.length > 0 && (
+        <div className="missing-banner">
+          <div className="missing-banner__left">
+            <CartIcon aria-hidden="true" />
+            <span>{missing.length} ingredient{missing.length !== 1 ? 's' : ''} missing from your pantry</span>
+          </div>
+          <button className="missing-banner__btn">Add to list</button>
+        </div>
+      )}
+
+      {/* Ingredients */}
+      <p className="section-label">Ingredients</p>
+      <div className="card card--list">
+        {recipe.ingredients.map((ing, i) => (
+          <div key={i} className="ing-row">
+            <div className="ing-row__left">
+              {ing.inPantry
+                ? <CheckCircleIcon className="icon--green" aria-hidden="true" />
+                : <AlertCircleIcon className="icon--amber" aria-hidden="true" />}
+              {ing.name}
+            </div>
+            <div className="ing-row__right">
+              <span className="ing-qty">{ing.quantity} {ing.unit}</span>
+              <PantryTag variant={ing.inPantry ? 'in-pantry' : 'missing'} />
+              {!ing.inPantry && (
+                <button className="add-list-btn" aria-label={`Add ${ing.name} to shopping list`}>
+                  + Add
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Steps */}
+      <p className="section-label">Steps</p>
+      <div className="card">
+        <div className="step-list">
+          {recipe.steps.map((step, i) => (
+            <div key={i} className="step-row">
+              <div className="step-num" aria-hidden="true">{i + 1}</div>
+              <p className="step-text">{step}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* CTAs */}
+      <div className="cta-row">
+        <button className="btn btn--primary" onClick={onApprove}>
+          <CheckIcon aria-hidden="true" /> Approve
+        </button>
+        <button className="btn btn--secondary" onClick={onRetry}>
+          <RefreshIcon aria-hidden="true" /> Retry
+        </button>
+      </div>
+      <p className="approve-hint">Approving saves this recipe to your collection</p>
+    </>
+  );
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+function ChipGroup({ label, options, value, onChange }) {
+  return (
+    <div>
+      <p className="section-label">{label}</p>
+      <div className="chips-row">
+        {options.map(opt => (
+          <button
+            key={opt}
+            className={`chip ${value === opt ? 'chip--active' : ''}`}
+            onClick={() => onChange(opt)}
+            aria-pressed={value === opt}
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function AdjustIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><line x1="4" y1="6" x2="20" y2="6" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="18" x2="20" y2="18" /><circle cx="8" cy="6" r="2" fill="currentColor" stroke="none" /><circle cx="16" cy="12" r="2" fill="currentColor" stroke="none" /><circle cx="10" cy="18" r="2" fill="currentColor" stroke="none" /></svg>;
+}
+function SparklesIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3 L13.5 8.5 L19 10 L13.5 11.5 L12 17 L10.5 11.5 L5 10 L10.5 8.5 Z" /></svg>;
+}
+function BasketIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" /><line x1="3" y1="6" x2="21" y2="6" /><path d="M16 10a4 4 0 0 1-8 0" /></svg>;
+}
+function ClockIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>;
+}
+function ChefHatIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" /><line x1="6" y1="17" x2="18" y2="17" /></svg>;
+}
+function UsersIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>;
+}
+function CartIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="9" cy="21" r="1" /><circle cx="20" cy="21" r="1" /><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" /></svg>;
+}
+function CheckCircleIcon({ className, ...props }) {
+  return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" /></svg>;
+}
+function AlertCircleIcon({ className, ...props }) {
+  return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>;
+}
+function CheckIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>;
+}
+function RefreshIcon(props) {
+  return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" /></svg>;
 }

--- a/apps/web/src/pages/Home.jsx
+++ b/apps/web/src/pages/Home.jsx
@@ -1,4 +1,159 @@
-// TODO: fetch and display personalised recipe feed
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import RecipeCard from '../components/RecipeCard.jsx';
+import Toast from '../components/Toast.jsx';
+import { FAKE_STATS, FAKE_SUGGESTIONS } from '../data/fakeData.js';
+
+/**
+ * Home — three states from home_screen_v2 wireframe:
+ *   'default'  → hero card + stats + collapsed suggestion list
+ *   'expanded' → a recipe card expanded inline
+ *   'post-cook'→ toast shown, stats updated, suggestion list trimmed
+ */
+
 export default function Home() {
-  return <div className="page">Home — recipe feed placeholder</div>;
+  const navigate = useNavigate();
+  const [stats, setStats] = useState(FAKE_STATS);
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastMsg, setToastMsg] = useState('');
+
+  const handleCook = useCallback((recipe) => {
+    const removed = recipe.ingredients.filter(i => i.inPantry).length;
+    setStats(s => ({ ...s, pantryCount: Math.max(0, s.pantryCount - removed) }));
+    setToastMsg(`Cooked! Removed ${removed} ingredient${removed !== 1 ? 's' : ''} from your pantry.`);
+    setToastVisible(true);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    setToastMsg('Recipe saved to your collection.');
+    setToastVisible(true);
+  }, []);
+
+  const greeting = getGreeting();
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <h1 className="page-title">
+          {greeting}, {/* TODO: replace with user.displayName */}Jamie
+        </h1>
+        <button className="icon-btn" aria-label="Notifications">
+          <BellIcon />
+        </button>
+      </div>
+
+      <Toast
+        message={toastMsg}
+        visible={toastVisible}
+        onDismiss={() => setToastVisible(false)}
+      />
+
+      {/* Hero card */}
+      <div className="hero-card">
+        <h2 className="hero-card__title">What can I cook today?</h2>
+        <p className="hero-card__body">
+          You have {stats.pantryCount} items in your pantry. Let Chef find something delicious.
+        </p>
+        <button className="hero-card__cta" onClick={() => navigate('/chef')}>
+          <SparklesIcon aria-hidden="true" /> Open Chef
+        </button>
+      </div>
+
+      {/* Stats row */}
+      <div className="stats-row">
+        <div className="stat-card">
+          <BasketIcon className="stat-card__icon" aria-hidden="true" />
+          <span className="stat-card__value">{stats.pantryCount}</span>
+          <span className="stat-card__label">Pantry items</span>
+        </div>
+        <div className="stat-card">
+          <BookmarkIcon className="stat-card__icon" aria-hidden="true" />
+          <span className="stat-card__value">{stats.savedCount}</span>
+          <span className="stat-card__label">Saved recipes</span>
+        </div>
+      </div>
+
+      {/* Suggestion list */}
+      <p className="section-label">Suggested for you</p>
+      <div className="suggestion-list">
+        {FAKE_SUGGESTIONS.map((recipe, idx) => (
+          <div key={recipe.id}>
+            {idx > 0 && <div className="divider" />}
+            <RecipeCard
+              recipe={recipe}
+              showMatchPill
+              actions={[
+                {
+                  label: 'Cook this',
+                  icon: ChefHatIcon,
+                  onClick: () => handleCook(recipe),
+                  variant: 'primary',
+                },
+                {
+                  label: 'Save',
+                  icon: BookmarkIcon,
+                  onClick: handleSave,
+                  variant: 'secondary',
+                },
+              ]}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="page-bottom" />
+    </div>
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getGreeting() {
+  const h = new Date().getHours();
+  if (h < 12) return 'Good morning';
+  if (h < 17) return 'Good afternoon';
+  return 'Good evening';
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function BellIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  );
+}
+
+function SparklesIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3 L13.5 8.5 L19 10 L13.5 11.5 L12 17 L10.5 11.5 L5 10 L10.5 8.5 Z" />
+    </svg>
+  );
+}
+
+function BasketIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" /><line x1="3" y1="6" x2="21" y2="6" /><path d="M16 10a4 4 0 0 1-8 0" />
+    </svg>
+  );
+}
+
+function BookmarkIcon({ className }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16Z" />
+    </svg>
+  );
+}
+
+function ChefHatIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" /><line x1="6" y1="17" x2="18" y2="17" />
+    </svg>
+  );
 }

--- a/apps/web/src/pages/Pantry.jsx
+++ b/apps/web/src/pages/Pantry.jsx
@@ -1,4 +1,414 @@
-// TODO: implement pantry list, add/edit/delete items, voice-add flow
+import { useState, useMemo } from 'react';
+import { FAKE_PANTRY, INGREDIENT_CATALOGUE } from '../data/fakeData.js';
+
+/**
+ * Pantry — main grid view + full-screen Add Item flow.
+ *
+ * States:
+ *   view='main'     → ingredient grid with category filters + FAB
+ *   view='add'      → full-screen Add Item sheet (Scan / Voice / Manual tabs)
+ *
+ * Add Item sub-states (tab):
+ *   'scan'     → camera viewport placeholder + manual fallback
+ *   'voice'    → mic button; voiceState='idle'|'listening'|'parsed'
+ *   'manual'   → autosuggest input → item confirmation form
+ */
+
+const CATEGORIES = ['All', 'Produce', 'Dairy', 'Grains', 'Protein', 'Other'];
+
 export default function Pantry() {
-  return <div className="page">Pantry — ingredient list placeholder</div>;
+  const [view, setView] = useState('main');   // 'main' | 'add'
+  const [search, setSearch] = useState('');
+  const [activeCategory, setActiveCategory] = useState('All');
+
+  // Flatten pantry for filtering
+  const allItems = useMemo(() => Object.entries(FAKE_PANTRY).flatMap(
+    ([cat, items]) => items.map(item => ({ ...item, category: cat }))
+  ), []);
+
+  const filtered = useMemo(() => {
+    const bySearch = search
+      ? allItems.filter(i => i.name.toLowerCase().includes(search.toLowerCase()))
+      : allItems;
+    return activeCategory === 'All'
+      ? bySearch
+      : bySearch.filter(i => i.category === activeCategory);
+  }, [allItems, search, activeCategory]);
+
+  // Group filtered items by category
+  const grouped = useMemo(() => {
+    const result = {};
+    for (const item of filtered) {
+      (result[item.category] ??= []).push(item);
+    }
+    return result;
+  }, [filtered]);
+
+  if (view === 'add') {
+    return <AddItemScreen onBack={() => setView('main')} />;
+  }
+
+  return (
+    <div className="page page--relative">
+      <div className="page-header">
+        <h1 className="page-title">My pantry</h1>
+        <span className="page-count">{allItems.length} items</span>
+      </div>
+
+      {/* Search */}
+      <div className="search-bar">
+        <SearchIcon aria-hidden="true" />
+        <input
+          className="search-bar__input"
+          placeholder="Search ingredients…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          aria-label="Search pantry"
+        />
+        {search && (
+          <button className="search-bar__clear" onClick={() => setSearch('')} aria-label="Clear search">×</button>
+        )}
+      </div>
+
+      {/* Category chips */}
+      <div className="chips-row">
+        {CATEGORIES.map(cat => (
+          <button
+            key={cat}
+            className={`chip ${activeCategory === cat ? 'chip--active' : ''}`}
+            onClick={() => setActiveCategory(cat)}
+            aria-pressed={activeCategory === cat}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      {/* Ingredient grid by category */}
+      {Object.entries(grouped).map(([cat, items]) => (
+        <div key={cat}>
+          <p className="cat-label">{cat}</p>
+          <div className="ing-grid">
+            {items.map(item => (
+              <div key={item.id} className="ing-tile">
+                <div className="ing-tile__icon" aria-hidden="true" />
+                <div>
+                  <div className="ing-tile__name">{item.name}</div>
+                  <div className="ing-tile__qty">{item.quantity} {item.unit}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {filtered.length === 0 && (
+        <p className="empty-state">No ingredients match "{search}"</p>
+      )}
+
+      {/* FAB */}
+      <button className="fab" onClick={() => setView('add')} aria-label="Add ingredient">
+        <PlusIcon aria-hidden="true" />
+      </button>
+
+      <div className="page-bottom" />
+    </div>
+  );
 }
+
+// ── Add Item full-screen ───────────────────────────────────────────────────────
+
+function AddItemScreen({ onBack }) {
+  const [tab, setTab] = useState('scan'); // 'scan' | 'voice' | 'manual'
+
+  const TABS = [
+    { id: 'scan',   label: 'Scan',   icon: ScanIcon },
+    { id: 'voice',  label: 'Voice',  icon: MicIcon },
+    { id: 'manual', label: 'Manual', icon: PencilIcon },
+  ];
+
+  return (
+    <div className="page">
+      <div className="fs-nav">
+        <button className="back-btn" onClick={onBack}>
+          <ArrowLeftIcon aria-hidden="true" /> Pantry
+        </button>
+        <h1 className="fs-nav__title">Add item</h1>
+        <div className="fs-nav__spacer" />
+      </div>
+
+      {/* Method tabs */}
+      <div className="method-tabs">
+        {TABS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            className={`method-tab ${tab === id ? 'method-tab--active' : ''}`}
+            onClick={() => setTab(id)}
+            aria-pressed={tab === id}
+          >
+            <Icon aria-hidden="true" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'scan'   && <ScanTab onSwitchManual={() => setTab('manual')} />}
+      {tab === 'voice'  && <VoiceTab onBack={onBack} />}
+      {tab === 'manual' && <ManualTab onBack={onBack} />}
+
+      <div className="page-bottom" />
+    </div>
+  );
+}
+
+// ── Scan tab ──────────────────────────────────────────────────────────────────
+
+function ScanTab({ onSwitchManual }) {
+  return (
+    <>
+      <div className="scan-viewport" aria-label="Camera viewfinder">
+        <div className="scan-corner scan-corner--tl" />
+        <div className="scan-corner scan-corner--tr" />
+        <div className="scan-corner scan-corner--bl" />
+        <div className="scan-corner scan-corner--br" />
+        <div className="scan-line" />
+      </div>
+      <p className="scan-hint">Point your camera at a barcode or food label</p>
+      <div className="scan-or">
+        <div className="scan-or__line" />
+        <span>or add manually</span>
+        <div className="scan-or__line" />
+      </div>
+      <button className="manual-trigger" onClick={onSwitchManual}>
+        <PencilIcon aria-hidden="true" /> Type an ingredient instead
+      </button>
+    </>
+  );
+}
+
+// ── Voice tab ─────────────────────────────────────────────────────────────────
+
+const FAKE_PARSED = [
+  { name: 'Eggs',   quantity: 6,   unit: 'pcs' },
+  { name: 'Rice',   quantity: 500, unit: 'g' },
+  { name: 'Onions', quantity: 2,   unit: 'pcs' },
+  { name: 'Milk',   quantity: 1,   unit: 'L' },
+];
+
+function VoiceTab({ onBack }) {
+  const [voiceState, setVoiceState] = useState('idle'); // 'idle' | 'listening' | 'parsed'
+
+  function handleMicTap() {
+    if (voiceState === 'idle') {
+      setVoiceState('listening');
+      // Simulate 2 s of listening then parse
+      setTimeout(() => setVoiceState('parsed'), 2000);
+    } else if (voiceState === 'listening') {
+      setVoiceState('parsed');
+    }
+  }
+
+  function handleRedo() {
+    setVoiceState('idle');
+  }
+
+  return (
+    <div className="voice-area">
+      {voiceState !== 'parsed' && (
+        <>
+          <button
+            className={`mic-ring ${voiceState === 'listening' ? 'mic-ring--active' : ''}`}
+            onClick={handleMicTap}
+            aria-label={voiceState === 'listening' ? 'Stop listening' : 'Start listening'}
+          >
+            <MicIcon aria-hidden="true" />
+          </button>
+          <p className="voice-hint">
+            {voiceState === 'listening'
+              ? 'Listening… tap to stop'
+              : 'Tap the mic and say your ingredients.\nYou can list multiple at once.'}
+          </p>
+          {voiceState === 'idle' && (
+            <div className="voice-example">"6 eggs, 500g of rice, 2 onions, 1L of milk"</div>
+          )}
+        </>
+      )}
+
+      {voiceState === 'parsed' && (
+        <>
+          <p className="section-label">Heard {FAKE_PARSED.length} items — confirm to add</p>
+          <div className="voice-parsed">
+            {FAKE_PARSED.map((item, i) => (
+              <div key={i} className="parsed-row">
+                <div className="parsed-row__name">
+                  <CheckCircleIcon aria-hidden="true" /> {item.name}
+                </div>
+                <span className="parsed-row__qty">{item.quantity} {item.unit}</span>
+              </div>
+            ))}
+          </div>
+          <div className="cta-row">
+            <button className="btn btn--secondary" onClick={handleRedo}>
+              <MicIcon aria-hidden="true" /> Redo
+            </button>
+            <button className="btn btn--primary btn--flex2" onClick={onBack}>
+              <PlusCircleIcon aria-hidden="true" /> Add all to pantry
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Manual tab ────────────────────────────────────────────────────────────────
+
+const UNITS_BY_CAT = {
+  Produce: ['pcs', 'g', 'kg'],
+  Dairy:   ['pcs', 'ml', 'g'],
+  Grains:  ['g', 'kg', 'cups'],
+  Protein: ['g', 'kg', 'pcs'],
+  Other:   ['g', 'ml', 'tsp', 'tbsp'],
+};
+
+function ManualTab({ onBack }) {
+  const [query, setQuery]         = useState('');
+  const [selected, setSelected]   = useState(null);
+  const [quantity, setQuantity]   = useState('');
+  const [unit, setUnit]           = useState('');
+  const [category, setCategory]   = useState('');
+
+  const suggestions = useMemo(() => {
+    if (!query || selected) return [];
+    return INGREDIENT_CATALOGUE
+      .filter(i => i.name.toLowerCase().includes(query.toLowerCase()))
+      .slice(0, 5);
+  }, [query, selected]);
+
+  function handleSelect(ing) {
+    setSelected(ing);
+    setQuery(ing.name);
+    setUnit(ing.defaultUnit);
+    setCategory(ing.category);
+  }
+
+  function handleClear() {
+    setSelected(null);
+    setQuery('');
+    setUnit('');
+    setCategory('');
+  }
+
+  const unitOptions = UNITS_BY_CAT[category] ?? ['g', 'ml', 'pcs'];
+
+  return (
+    <>
+      {/* Ingredient name field */}
+      <div className="form-field">
+        <label className="form-label" htmlFor="ing-name">Ingredient name</label>
+        <div className={`form-input ${selected ? 'form-input--selected' : query ? 'form-input--active' : ''}`}>
+          <input
+            id="ing-name"
+            className="form-input__text"
+            placeholder="Type an ingredient…"
+            value={query}
+            onChange={e => { setQuery(e.target.value); setSelected(null); }}
+            autoComplete="off"
+          />
+          {(query || selected) && (
+            <button className="form-input__clear" onClick={handleClear} aria-label="Clear">
+              {selected ? <CheckCircleIcon className="icon--primary" aria-hidden="true" /> : '×'}
+            </button>
+          )}
+        </div>
+
+        {suggestions.length > 0 && (
+          <div className="autosuggest-list">
+            {suggestions.map(ing => (
+              <div key={ing.id} className="suggest-row" onClick={() => handleSelect(ing)} role="button" tabIndex={0}
+                onKeyDown={e => e.key === 'Enter' && handleSelect(ing)}>
+                <div className="suggest-row__icon" aria-hidden="true" />
+                <div>
+                  <div className="suggest-row__name">{ing.name}</div>
+                  <div className="suggest-row__cat">{ing.category}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <>
+          {/* Quantity + unit */}
+          <div className="qty-unit-row">
+            <div className="form-field">
+              <label className="form-label" htmlFor="ing-qty">Quantity</label>
+              <input
+                id="ing-qty"
+                className="form-input form-input--text"
+                type="number"
+                min="0"
+                placeholder="0"
+                value={quantity}
+                onChange={e => setQuantity(e.target.value)}
+              />
+            </div>
+            <div className="form-field">
+              <label className="form-label" htmlFor="ing-unit">Unit</label>
+              <div className="unit-selector">
+                <select
+                  id="ing-unit"
+                  className="unit-selector__select"
+                  value={unit}
+                  onChange={e => setUnit(e.target.value)}
+                >
+                  {unitOptions.map(u => <option key={u} value={u}>{u}</option>)}
+                </select>
+                {unit === selected.defaultUnit && (
+                  <span className="unit-auto-badge">Auto</span>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Category */}
+          <div className="form-field">
+            <label className="form-label">Category</label>
+            <div className="chips-row">
+              {['Produce', 'Protein', 'Dairy', 'Grains', 'Other'].map(cat => (
+                <button
+                  key={cat}
+                  className={`chip chip--sm ${category === cat ? 'chip--secondary' : ''}`}
+                  onClick={() => setCategory(cat)}
+                  aria-pressed={category === cat}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <button
+            className="btn btn--primary btn--large btn--full"
+            onClick={onBack}
+            disabled={!quantity}
+          >
+            <PlusCircleIcon aria-hidden="true" /> Add to pantry
+          </button>
+        </>
+      )}
+    </>
+  );
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function SearchIcon(props)     { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>; }
+function PlusIcon(props)       { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>; }
+function PlusCircleIcon(props) { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="16" /><line x1="8" y1="12" x2="16" y2="12" /></svg>; }
+function ArrowLeftIcon(props)  { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><line x1="19" y1="12" x2="5" y2="12" /><polyline points="12 19 5 12 12 5" /></svg>; }
+function ScanIcon(props)       { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M3 7V5a2 2 0 0 1 2-2h2" /><path d="M17 3h2a2 2 0 0 1 2 2v2" /><path d="M21 17v2a2 2 0 0 1-2 2h-2" /><path d="M7 21H5a2 2 0 0 1-2-2v-2" /><line x1="3" y1="12" x2="21" y2="12" /></svg>; }
+function MicIcon(props)        { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" /><path d="M19 10v2a7 7 0 0 1-14 0v-2" /><line x1="12" y1="19" x2="12" y2="23" /><line x1="8" y1="23" x2="16" y2="23" /></svg>; }
+function PencilIcon(props)     { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>; }
+function CheckCircleIcon({ className, ...props }) { return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" /></svg>; }

--- a/apps/web/src/pages/Profile.jsx
+++ b/apps/web/src/pages/Profile.jsx
@@ -1,4 +1,127 @@
-// TODO: show user profile, dietary preferences, sign-out button
+import { useState } from 'react';
+import { FAKE_USER, FAKE_STATS } from '../data/fakeData.js';
+
+/**
+ * Profile — from saved_and_profile_v2 wireframe.
+ *
+ * Sections:
+ *   - Avatar + name + sub-label
+ *   - Stats row (Saved / Pantry items / Cooked)
+ *   - Dietary preferences (local toggle state only)
+ *   - Account rows (Edit profile, Notifications, Log out)
+ */
+
+const PREFS_CONFIG = [
+  { key: 'vegetarian', label: 'Vegetarian',    icon: LeafIcon },
+  { key: 'glutenFree', label: 'Gluten-free',   icon: WheatIcon },
+  { key: 'highProtein',label: 'High protein',  icon: BarbellIcon },
+  { key: 'macroTracking', label: 'Macro tracking', icon: HeartIcon },
+];
+
 export default function Profile() {
-  return <div className="page">Profile — user settings placeholder</div>;
+  const [prefs, setPrefs] = useState({
+    vegetarian:    false,
+    glutenFree:    false,
+    highProtein:   true,
+    macroTracking: true,
+  });
+
+  function togglePref(key) {
+    setPrefs(p => ({ ...p, [key]: !p[key] }));
+  }
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <h1 className="page-title">Profile</h1>
+        <button className="icon-btn" aria-label="Settings">
+          <SettingsIcon />
+        </button>
+      </div>
+
+      {/* Avatar + name */}
+      <div className="profile-header">
+        <div className="profile-avatar" aria-label="Profile photo" />
+        <div className="profile-name">{FAKE_USER.displayName}</div>
+        <div className="profile-sub">{FAKE_USER.roleLabel} · {FAKE_USER.city}</div>
+      </div>
+
+      {/* Stats row */}
+      <div className="profile-stats">
+        <div className="p-stat">
+          <div className="p-stat__val">{FAKE_STATS.savedCount}</div>
+          <div className="p-stat__lbl">Saved</div>
+        </div>
+        <div className="p-stat">
+          <div className="p-stat__val">{FAKE_STATS.pantryCount}</div>
+          <div className="p-stat__lbl">Pantry items</div>
+        </div>
+        <div className="p-stat">
+          <div className="p-stat__val">{FAKE_STATS.cookedCount}</div>
+          <div className="p-stat__lbl">Cooked</div>
+        </div>
+      </div>
+
+      {/* Dietary preferences */}
+      <p className="section-label">Dietary preferences</p>
+      <div className="info-note">
+        <SparklesIcon aria-hidden="true" />
+        <span>Chef uses these automatically. You can override them per generation on the Chef screen.</span>
+      </div>
+      <div className="card card--list-sm">
+        {PREFS_CONFIG.map(({ key, label, icon: Icon }) => (
+          <div key={key} className="pref-row">
+            <div className="pref-row__left">
+              <Icon aria-hidden="true" />
+              {label}
+            </div>
+            <button
+              className={`toggle ${prefs[key] ? 'toggle--on' : ''}`}
+              role="switch"
+              aria-checked={prefs[key]}
+              aria-label={`${label} ${prefs[key] ? 'on' : 'off'}`}
+              onClick={() => togglePref(key)}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Account rows */}
+      <p className="section-label">Account</p>
+      <div className="card card--list-sm">
+        <div className="pref-row">
+          <div className="pref-row__left">
+            <UserIcon aria-hidden="true" /> Edit profile
+          </div>
+          <ChevronRightIcon className="pref-row__arrow" aria-hidden="true" />
+        </div>
+        <div className="pref-row">
+          <div className="pref-row__left">
+            <BellIcon aria-hidden="true" /> Notifications
+          </div>
+          <ChevronRightIcon className="pref-row__arrow" aria-hidden="true" />
+        </div>
+        <div className="pref-row pref-row--danger">
+          <div className="pref-row__left pref-row__left--danger">
+            <LogOutIcon aria-hidden="true" /> Log out
+          </div>
+        </div>
+      </div>
+
+      <div className="page-bottom" />
+    </div>
+  );
 }
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function SettingsIcon(props)           { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>; }
+function SparklesIcon(props)           { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3 L13.5 8.5 L19 10 L13.5 11.5 L12 17 L10.5 11.5 L5 10 L10.5 8.5 Z" /></svg>; }
+function LeafIcon(props)               { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.48 19 2c1 2 2 4.18 2 8 0 5.5-4.78 10-10 10z" /><path d="M2 21c0-3 1.85-5.36 5.08-6C9.5 14.52 12 13 13 12" /></svg>; }
+function WheatIcon(props)              { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M2 22 12 12" /><path d="M7 12c-.55-3.84 1.5-7.13 4-9 .5 2.5 2 4.9 2 7-2 .5-4 .5-6 2z" /><path d="M17 12c.55-3.84-1.5-7.13-4-9-.5 2.5-2 4.9-2 7 2 .5 4 .5 6 2z" /><path d="M12 22c0-4-1.5-7-3-9" /><path d="M12 22c0-4 1.5-7 3-9" /></svg>; }
+function BarbellIcon(props)            { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><line x1="6" y1="5" x2="6" y2="19" /><line x1="18" y1="5" x2="18" y2="19" /><line x1="2" y1="9" x2="6" y2="9" /><line x1="2" y1="15" x2="6" y2="15" /><line x1="18" y1="9" x2="22" y2="9" /><line x1="18" y1="15" x2="22" y2="15" /><line x1="6" y1="12" x2="18" y2="12" /></svg>; }
+function HeartIcon(props)              { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" /></svg>; }
+function UserIcon(props)               { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" /></svg>; }
+function BellIcon(props)               { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" /></svg>; }
+function LogOutIcon(props)             { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></svg>; }
+function ChevronRightIcon({ className, ...props }) { return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>; }

--- a/apps/web/src/pages/Saved.jsx
+++ b/apps/web/src/pages/Saved.jsx
@@ -1,4 +1,213 @@
-// TODO: display saved/bookmarked recipes, allow unsaving
+import { useState, useMemo } from 'react';
+import MatchBar from '../components/MatchBar.jsx';
+import PantryTag from '../components/PantryTag.jsx';
+import Toast from '../components/Toast.jsx';
+import { FAKE_SAVED } from '../data/fakeData.js';
+
+/**
+ * Saved — list + expanded card, from saved_and_profile_v2 wireframe.
+ *
+ * States:
+ *   'list'     → collapsed recipe cards with match bar
+ *   expandedId → one recipe expanded inline (click to expand/collapse)
+ */
+
+const FILTERS = ['All', 'Breakfast', 'Lunch', 'Dinner', 'Chef picks'];
+
 export default function Saved() {
-  return <div className="page">Saved — bookmarked recipes placeholder</div>;
+  const [search, setSearch]         = useState('');
+  const [activeFilter, setFilter]   = useState('All');
+  const [expandedId, setExpandedId] = useState(null);
+  const [recipes, setRecipes]       = useState(FAKE_SAVED);
+  const [toast, setToast]           = useState({ visible: false, msg: '' });
+
+  function showToast(msg) { setToast({ visible: true, msg }); }
+
+  const filtered = useMemo(() => {
+    let list = recipes;
+    if (search) list = list.filter(r => r.name.toLowerCase().includes(search.toLowerCase()));
+    if (activeFilter === 'Chef picks') list = list.filter(r => r.isChefPick);
+    else if (activeFilter !== 'All') list = list.filter(r => r.mealType === activeFilter);
+    return list;
+  }, [recipes, search, activeFilter]);
+
+  function handleCook(recipe) {
+    showToast(`Cooked! Removed ${recipe.ingredients.filter(i => i.inPantry).length} ingredients from your pantry.`);
+    setExpandedId(null);
+  }
+
+  function handleDelete(id) {
+    setRecipes(rs => rs.filter(r => r.id !== id));
+    setExpandedId(null);
+    showToast('Recipe removed from saved.');
+  }
+
+  return (
+    <div className="page">
+      <div className="page-header">
+        <h1 className="page-title">Saved recipes</h1>
+        <span className="page-count">{recipes.length} recipes</span>
+      </div>
+
+      <Toast message={toast.msg} visible={toast.visible} onDismiss={() => setToast(t => ({ ...t, visible: false }))} />
+
+      {/* Search */}
+      <div className="search-bar">
+        <SearchIcon aria-hidden="true" />
+        <input
+          className="search-bar__input"
+          placeholder="Search saved recipes…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          aria-label="Search saved recipes"
+        />
+      </div>
+
+      {/* Filter chips */}
+      <div className="chips-row">
+        {FILTERS.map(f => (
+          <button
+            key={f}
+            className={`chip ${activeFilter === f ? 'chip--active' : ''}`}
+            onClick={() => setFilter(f)}
+            aria-pressed={activeFilter === f}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
+      {/* Recipe list */}
+      {filtered.length === 0 && (
+        <p className="empty-state">No saved recipes match your filters.</p>
+      )}
+
+      {filtered.map(recipe =>
+        expandedId === recipe.id ? (
+          <ExpandedRecipe
+            key={recipe.id}
+            recipe={recipe}
+            onCollapse={() => setExpandedId(null)}
+            onCook={() => handleCook(recipe)}
+            onDelete={() => handleDelete(recipe.id)}
+          />
+        ) : (
+          <CollapsedRecipe
+            key={recipe.id}
+            recipe={recipe}
+            onExpand={() => setExpandedId(recipe.id)}
+          />
+        )
+      )}
+
+      <div className="page-bottom" />
+    </div>
+  );
 }
+
+// ── Collapsed recipe card ─────────────────────────────────────────────────────
+
+function CollapsedRecipe({ recipe, onExpand }) {
+  return (
+    <div className="recipe-card" onClick={onExpand} role="button" tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && onExpand()}
+      aria-label={`Expand ${recipe.name}`}
+    >
+      <div className="recipe-card__main">
+        <div className="recipe-card__thumb" aria-hidden="true" />
+        <div className="recipe-card__body">
+          <div className="recipe-card__name">{recipe.name}</div>
+          <div className="recipe-card__meta">
+            <ClockIcon aria-hidden="true" /> {recipe.cookTime} min
+            <ChefHatIcon aria-hidden="true" style={{ marginLeft: 4 }} /> {recipe.difficulty}
+          </div>
+          <div className="recipe-card__tags">
+            <span className="r-tag">{recipe.mealType}</span>
+            {recipe.isChefPick && (
+              <span className="r-tag r-tag--chef">
+                <SparklesIcon aria-hidden="true" /> Chef
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+      <MatchBar pct={recipe.matchPct} className="recipe-card__match-bar" />
+    </div>
+  );
+}
+
+// ── Expanded recipe card ──────────────────────────────────────────────────────
+
+function ExpandedRecipe({ recipe, onCollapse, onCook, onDelete }) {
+  return (
+    <div className="expanded-recipe">
+      <button className="expanded-recipe__header" onClick={onCollapse} aria-label="Collapse recipe">
+        <div className="expanded-recipe__title-row">
+          <span className="expanded-recipe__title">{recipe.name}</span>
+          {recipe.isChefPick && (
+            <span className="chef-badge">
+              <SparklesIcon aria-hidden="true" /> Chef
+            </span>
+          )}
+        </div>
+        <div className="expanded-recipe__meta">
+          <span><ClockIcon aria-hidden="true" /> {recipe.cookTime} min</span>
+          <span><ChefHatIcon aria-hidden="true" /> {recipe.difficulty}</span>
+          <span><UsersIcon aria-hidden="true" /> {recipe.servings} servings</span>
+        </div>
+      </button>
+
+      <MatchBar pct={recipe.matchPct} className="expanded-recipe__match-bar" />
+
+      <div className="expanded-recipe__body">
+        <p className="section-label">Ingredients</p>
+        <div className="ing-list-bg">
+          {recipe.ingredients.map((ing, i) => (
+            <div key={i} className="ing-row-sm">
+              <div className="ing-row-sm__left">
+                {ing.inPantry
+                  ? <CheckCircleIcon className="icon--green" aria-hidden="true" />
+                  : <AlertCircleIcon className="icon--amber" aria-hidden="true" />}
+                {ing.name}
+              </div>
+              <div className="ing-row-sm__right">
+                <span className="ing-qty-sm">{ing.quantity} {ing.unit}</span>
+                <PantryTag variant={ing.inPantry ? 'in-pantry' : 'missing'} />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p className="section-label">Steps</p>
+        <div className="step-list">
+          {recipe.steps.map((step, i) => (
+            <div key={i} className="step-row-sm">
+              <div className="step-num-sm" aria-hidden="true">{i + 1}</div>
+              <p className="step-text-sm">{step}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="expanded-cta-row">
+          <button className="btn btn--primary btn--flex2" onClick={onCook}>
+            <ChefHatIcon aria-hidden="true" /> Cook this
+          </button>
+          <button className="btn btn--danger" onClick={onDelete}>
+            <TrashIcon aria-hidden="true" /> Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+function SearchIcon(props)    { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>; }
+function ClockIcon(props)     { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>; }
+function ChefHatIcon(props)   { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M6 13.87A4 4 0 0 1 7.41 6a5.11 5.11 0 0 1 1.05-1.54 5 5 0 0 1 7.08 0A5.11 5.11 0 0 1 16.59 6 4 4 0 0 1 18 13.87V21H6Z" /><line x1="6" y1="17" x2="18" y2="17" /></svg>; }
+function UsersIcon(props)     { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>; }
+function SparklesIcon(props)  { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M12 3 L13.5 8.5 L19 10 L13.5 11.5 L12 17 L10.5 11.5 L5 10 L10.5 8.5 Z" /></svg>; }
+function TrashIcon(props)     { return <svg {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /></svg>; }
+function CheckCircleIcon({ className, ...props }) { return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" /><polyline points="22 4 12 14.01 9 11.01" /></svg>; }
+function AlertCircleIcon({ className, ...props }) { return <svg className={className} {...props} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" /></svg>; }

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -1,0 +1,1698 @@
+/**
+ * Plated component styles
+ *
+ * All colors come from tokens.css — no hardcoded hex values here.
+ * Organised by: base → layout → components → pages → utilities
+ */
+
+/* ── Reset / base ───────────────────────────────────────────────────────────── */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body, #root {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--text-base);
+  line-height: 1.5;
+  color: var(--color-text-primary);
+  background: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button { font-family: inherit; cursor: pointer; border: none; background: none; }
+input, textarea, select { font-family: inherit; }
+a { color: inherit; text-decoration: none; }
+svg { display: block; flex-shrink: 0; }
+
+/* ── App shell ──────────────────────────────────────────────────────────────── */
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  background: var(--color-bg);
+  position: relative;
+  overflow: hidden;
+}
+
+.app-main {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ── Page layout ────────────────────────────────────────────────────────────── */
+
+.page {
+  padding: var(--space-6);
+  padding-bottom: calc(var(--tab-height) + var(--space-6));
+  min-height: 100%;
+}
+
+.page--relative { position: relative; }
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+}
+
+.page-title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  letter-spacing: -0.3px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.page-count {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.page-bottom { height: var(--space-8); }
+
+/* ── Tab bar ────────────────────────────────────────────────────────────────── */
+
+.tab-bar {
+  display: flex;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  height: var(--tab-height);
+  flex-shrink: 0;
+}
+
+.tab-bar__item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: var(--space-2) 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  transition: color var(--transition-fast);
+}
+
+.tab-bar__item svg { width: 22px; height: 22px; }
+
+.tab-bar__item--active {
+  color: var(--color-primary);
+}
+
+/* ── Cards ──────────────────────────────────────────────────────────────────── */
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.card--row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.card--list {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card--list-sm {
+  padding: 0;
+  overflow: hidden;
+}
+
+.card__title {
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.card__subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+/* ── Section label ──────────────────────────────────────────────────────────── */
+
+.section-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-2);
+  margin-top: var(--space-6);
+}
+
+.section-label:first-child { margin-top: 0; }
+
+.section-label-optional {
+  font-weight: 400;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* ── Divider ────────────────────────────────────────────────────────────────── */
+
+.divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: var(--space-6) 0;
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────────────── */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 10px var(--space-6);
+  border-radius: var(--radius-full);
+  font-size: var(--text-md);
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+  white-space: nowrap;
+}
+
+.btn:active { transform: scale(0.97); }
+.btn svg { width: 16px; height: 16px; }
+
+.btn--primary {
+  background: var(--color-primary);
+  color: var(--color-surface);
+}
+
+.btn--primary:hover { opacity: 0.9; }
+
+.btn--secondary {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  border: 1.5px solid var(--color-border-strong);
+}
+
+.btn--danger {
+  background: var(--color-match-low-bg);
+  color: var(--color-match-low-text);
+}
+
+.btn--large {
+  padding: 14px var(--space-7);
+  font-size: var(--text-lg);
+}
+
+.btn--full { width: 100%; }
+
+.btn--flex2 { flex: 2; }
+
+.text-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-md);
+  font-weight: 600;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.text-btn--primary { color: var(--color-primary); }
+.text-btn svg { width: 16px; height: 16px; }
+
+.icon-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.icon-btn:hover { background: var(--color-border); }
+.icon-btn svg { width: 20px; height: 20px; }
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.back-btn svg { width: 18px; height: 18px; }
+
+/* ── FAB ─────────────────────────────────────────────────────────────────────── */
+
+.fab {
+  position: fixed;
+  bottom: calc(var(--tab-height) + var(--space-4));
+  right: calc(50% - var(--max-width) / 2 + var(--space-4));
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: var(--color-surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+  border: none;
+  cursor: pointer;
+  transition: transform var(--transition-fast), opacity var(--transition-fast);
+  z-index: 10;
+}
+
+.fab:active { transform: scale(0.94); }
+.fab svg { width: 22px; height: 22px; }
+
+/* ── Chips ───────────────────────────────────────────────────────────────────── */
+
+.chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.chip {
+  padding: 6px 14px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  border: 1.5px solid var(--color-border-strong);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.chip--active {
+  background: var(--color-primary);
+  color: var(--color-surface);
+  border-color: var(--color-primary);
+}
+
+.chip--sm {
+  padding: 4px 10px;
+  font-size: var(--text-2xs);
+}
+
+.chip--secondary {
+  background: var(--color-secondary);
+  color: var(--color-surface);
+  border-color: var(--color-secondary);
+}
+
+/* ── Match bar ───────────────────────────────────────────────────────────────── */
+
+.match-bar-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.match-bar-track {
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+  overflow: hidden;
+}
+
+.match-bar-fill {
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width 0.4s ease;
+}
+
+.match-bar-fill--high { background: var(--color-match-high-bar); }
+.match-bar-fill--mid  { background: var(--color-match-mid-bar); }
+.match-bar-fill--low  { background: var(--color-match-low-bar); }
+
+.match-bar-label {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+}
+
+.match-bar-fill--high + .match-bar-label,
+.match-bar-wrap .match-bar-label--high { color: var(--color-match-high-text); }
+.match-bar-fill--mid  + .match-bar-label,
+.match-bar-wrap .match-bar-label--mid  { color: var(--color-match-mid-text); }
+.match-bar-fill--low  + .match-bar-label,
+.match-bar-wrap .match-bar-label--low  { color: var(--color-match-low-text); }
+
+/* compact versions used in recipe cards */
+.recipe-card__match-bar,
+.expanded-recipe__match-bar {
+  margin-top: var(--space-2);
+}
+
+/* ── Pantry tag ──────────────────────────────────────────────────────────────── */
+
+.pantry-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pantry-tag--in-pantry {
+  background: var(--color-tag-in-pantry-bg);
+  color: var(--color-tag-in-pantry-text);
+}
+
+.pantry-tag--missing {
+  background: var(--color-tag-missing-bg);
+  color: var(--color-tag-missing-text);
+}
+
+/* ── Toast ───────────────────────────────────────────────────────────────────── */
+
+.toast {
+  position: fixed;
+  bottom: calc(var(--tab-height) + var(--space-4));
+  left: 50%;
+  transform: translateX(-50%) translateY(80px);
+  background: var(--color-toast-bg);
+  color: var(--color-surface);
+  border-radius: var(--radius-full);
+  padding: 10px var(--space-6);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  white-space: nowrap;
+  z-index: 100;
+  opacity: 0;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  max-width: calc(var(--max-width) - var(--space-8));
+}
+
+.toast--visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+.toast__icon {
+  color: var(--color-toast-check);
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.toast__message {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Search bar ──────────────────────────────────────────────────────────────── */
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-full);
+  padding: 10px var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.search-bar svg { width: 16px; height: 16px; color: var(--color-text-secondary); flex-shrink: 0; }
+
+.search-bar__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: none;
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+}
+
+.search-bar__input::placeholder { color: var(--color-text-disabled); }
+
+/* ── Form elements ───────────────────────────────────────────────────────────── */
+
+.form-field { margin-bottom: var(--space-4); }
+
+.form-label {
+  display: block;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-1);
+}
+
+.form-input,
+.auth-input {
+  width: 100%;
+  padding: 12px var(--space-4);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  font-size: var(--text-md);
+  color: var(--color-text-primary);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.form-input:focus,
+.auth-input:focus {
+  border-color: var(--color-primary);
+}
+
+.auth-input--error {
+  border-color: var(--color-primary);
+}
+
+.auth-input--with-toggle {
+  padding-right: 44px;
+}
+
+.auth-input-wrap {
+  position: relative;
+}
+
+.auth-input__toggle {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.auth-input__toggle svg { width: 18px; height: 18px; }
+
+.field-error {
+  font-size: var(--text-xs);
+  color: var(--color-primary);
+  margin-top: 4px;
+}
+
+.form-select {
+  width: 100%;
+  padding: 11px var(--space-4);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  font-size: var(--text-md);
+  color: var(--color-text-primary);
+  outline: none;
+  appearance: none;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236B6A65' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
+  padding-right: 36px;
+}
+
+.form-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-disabled);
+  margin-top: 4px;
+}
+
+.notes-field {
+  width: 100%;
+  padding: 12px var(--space-4);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  font-size: var(--text-md);
+  color: var(--color-text-primary);
+  outline: none;
+  resize: none;
+  transition: border-color var(--transition-fast);
+  line-height: 1.5;
+}
+
+.notes-field:focus { border-color: var(--color-primary); }
+
+/* ── Stepper ─────────────────────────────────────────────────────────────────── */
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  background: var(--color-bg);
+  border-radius: var(--radius-full);
+  padding: 4px;
+}
+
+.stepper__btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border-strong);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-lg);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.stepper__val {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  min-width: 24px;
+  text-align: center;
+}
+
+/* ── Toggle ──────────────────────────────────────────────────────────────────── */
+
+.toggle {
+  width: 44px;
+  height: 26px;
+  border-radius: var(--radius-full);
+  background: var(--color-toggle-off);
+  border: none;
+  cursor: pointer;
+  position: relative;
+  transition: background var(--transition-base);
+  flex-shrink: 0;
+}
+
+.toggle::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+  transition: transform var(--transition-base);
+}
+
+.toggle--on {
+  background: var(--color-toggle-on);
+}
+
+.toggle--on::after {
+  transform: translateX(18px);
+}
+
+/* ── Pref row (Profile) ──────────────────────────────────────────────────────── */
+
+.pref-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  gap: var(--space-4);
+}
+
+.pref-row:last-child { border-bottom: none; }
+
+.pref-row__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-md);
+  color: var(--color-text-primary);
+  font-weight: 500;
+}
+
+.pref-row__left svg { width: 18px; height: 18px; color: var(--color-text-secondary); }
+
+.pref-row__left--danger { color: var(--color-primary); }
+.pref-row__left--danger svg { color: var(--color-primary); }
+
+.pref-row--danger .pref-row__left { color: var(--color-primary); }
+
+.pref-row__arrow { width: 16px; height: 16px; color: var(--color-text-disabled); }
+
+/* ── Info note ───────────────────────────────────────────────────────────────── */
+
+.info-note {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  margin-bottom: var(--space-2);
+}
+
+.info-note svg { width: 14px; height: 14px; flex-shrink: 0; margin-top: 1px; }
+
+/* ── Empty state ─────────────────────────────────────────────────────────────── */
+
+.empty-state {
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: var(--text-md);
+  padding: var(--space-8) 0;
+}
+
+/* ── Icon utilities ──────────────────────────────────────────────────────────── */
+
+.icon--green { color: var(--color-match-high-bar); width: 16px; height: 16px; }
+.icon--amber { color: var(--color-match-low-bar); width: 16px; height: 16px; }
+.icon--primary { color: var(--color-primary); }
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   HOME SCREEN
+══════════════════════════════════════════════════════════════════════════════ */
+
+.hero-card {
+  background: var(--color-primary);
+  border-radius: var(--radius-2xl);
+  padding: var(--space-6);
+  color: var(--color-surface);
+  margin-bottom: var(--space-6);
+}
+
+.hero-card__eyebrow {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  opacity: 0.8;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  margin-bottom: var(--space-1);
+}
+
+.hero-card__name {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  margin-bottom: var(--space-2);
+}
+
+.hero-card__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-size: var(--text-sm);
+  opacity: 0.85;
+  margin-bottom: var(--space-4);
+}
+
+.hero-card__meta svg { width: 14px; height: 14px; }
+
+.hero-card .match-bar-track { background: rgba(255,255,255,0.25); }
+.hero-card .match-bar-label { color: rgba(255,255,255,0.9); }
+
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+
+.stat-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  text-align: center;
+}
+
+.stat-card__val {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.stat-card__lbl {
+  font-size: var(--text-2xs);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  margin-top: 2px;
+}
+
+/* ── Recipe card (collapsed) ─────────────────────────────────────────────────── */
+
+.recipe-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
+  cursor: pointer;
+  transition: box-shadow var(--transition-fast);
+}
+
+.recipe-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+
+.recipe-card__main {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.recipe-card__thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--color-secondary);
+  flex-shrink: 0;
+  opacity: 0.35;
+}
+
+.recipe-card__body { flex: 1; min-width: 0; }
+
+.recipe-card__name {
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.recipe-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-top: 3px;
+}
+
+.recipe-card__meta svg { width: 12px; height: 12px; }
+
+.recipe-card__tags {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* ── Recipe tags ─────────────────────────────────────────────────────────────── */
+
+.r-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.r-tag svg { width: 10px; height: 10px; }
+
+.r-tag--chef {
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+  border-color: transparent;
+}
+
+/* ── Suggestion list (home) ──────────────────────────────────────────────────── */
+
+.suggestion-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* ── Expanded recipe (Saved) ─────────────────────────────────────────────────── */
+
+.expanded-recipe {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--space-3);
+  overflow: hidden;
+}
+
+.expanded-recipe__header {
+  width: 100%;
+  text-align: left;
+  padding: var(--space-4);
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+.expanded-recipe__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: 4px;
+}
+
+.expanded-recipe__title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.chef-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+}
+
+.chef-badge svg { width: 10px; height: 10px; }
+
+.expanded-recipe__meta {
+  display: flex;
+  gap: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.expanded-recipe__meta span { display: flex; align-items: center; gap: 4px; }
+.expanded-recipe__meta svg { width: 12px; height: 12px; }
+
+.expanded-recipe__body {
+  padding: 0 var(--space-4) var(--space-4);
+}
+
+.expanded-cta-row {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+/* ── Ingredient rows ─────────────────────────────────────────────────────────── */
+
+.ing-list-bg {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.ing-row-sm {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  gap: var(--space-2);
+}
+
+.ing-row-sm:last-child { border-bottom: none; }
+
+.ing-row-sm__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+
+.ing-row-sm__right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.ing-qty-sm {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+/* ── Step rows (small, e.g. Saved expanded) ──────────────────────────────────── */
+
+.step-list { display: flex; flex-direction: column; gap: var(--space-3); }
+
+.step-row-sm {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.step-num-sm {
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.step-text-sm {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  padding-top: 2px;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   CHEF SCREEN
+══════════════════════════════════════════════════════════════════════════════ */
+
+.ai-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  background: var(--color-primary-bg);
+  color: var(--color-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  vertical-align: middle;
+}
+
+.pantry-note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--color-pantry-note-bg);
+  color: var(--color-pantry-note-text);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  margin-bottom: var(--space-6);
+}
+
+.pantry-note svg { width: 16px; height: 16px; flex-shrink: 0; }
+
+/* ── Generating state ────────────────────────────────────────────────────────── */
+
+.generating-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px var(--space-6);
+  gap: var(--space-4);
+}
+
+.generating-state__title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.generating-state__sub {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 3px solid var(--color-border);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Result state ────────────────────────────────────────────────────────────── */
+
+.result-header {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.result-header__title {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-2);
+}
+
+.result-header__meta {
+  display: flex;
+  gap: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.result-header__meta span { display: flex; align-items: center; gap: 4px; }
+.result-header__meta svg { width: 13px; height: 13px; }
+
+.missing-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--color-match-low-bg);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  gap: var(--space-4);
+}
+
+.missing-banner__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-match-low-dark);
+  font-weight: 500;
+}
+
+.missing-banner__left svg { width: 16px; height: 16px; }
+
+.missing-banner__btn {
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Ingredient rows (Chef result) ───────────────────────────────────────────── */
+
+.ing-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  gap: var(--space-2);
+}
+
+.ing-row:last-child { border-bottom: none; }
+
+.ing-row__left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+}
+
+.ing-row__left svg { width: 16px; height: 16px; }
+
+.ing-row__right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.ing-qty {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.add-list-btn {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  color: var(--color-primary);
+  background: var(--color-primary-bg);
+  border: none;
+  border-radius: var(--radius-full);
+  padding: 3px 10px;
+  cursor: pointer;
+}
+
+/* ── Step rows (Chef full size) ──────────────────────────────────────────────── */
+
+.step-row {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.step-row:first-child { padding-top: 0; }
+.step-row:last-child  { padding-bottom: 0; border-bottom: none; }
+
+.step-num {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.step-text {
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  line-height: 1.6;
+  padding-top: 4px;
+}
+
+/* ── CTAs (Chef) ─────────────────────────────────────────────────────────────── */
+
+.cta-row {
+  display: flex;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+.cta-row .btn { flex: 1; }
+
+.approve-hint {
+  text-align: center;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-2);
+}
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   PANTRY SCREEN
+══════════════════════════════════════════════════════════════════════════════ */
+
+.cat-label {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  margin: var(--space-6) 0 var(--space-2);
+}
+
+.cat-label:first-of-type { margin-top: 0; }
+
+.ing-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.ing-tile {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-3) var(--space-2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+
+.ing-tile__emoji {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.ing-tile__name {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.ing-tile__qty {
+  font-size: var(--text-2xs);
+  color: var(--color-text-secondary);
+}
+
+/* ── Add item screen ─────────────────────────────────────────────────────────── */
+
+.fs-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+}
+
+.fs-nav h2 {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+/* ── Method tabs ─────────────────────────────────────────────────────────────── */
+
+.method-tabs {
+  display: flex;
+  background: var(--color-bg);
+  border-radius: var(--radius-full);
+  padding: 4px;
+  margin-bottom: var(--space-6);
+  gap: 4px;
+}
+
+.method-tab {
+  flex: 1;
+  padding: 8px var(--space-2);
+  border-radius: var(--radius-full);
+  border: none;
+  background: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.method-tab svg { width: 14px; height: 14px; }
+
+.method-tab--active {
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+/* ── Scan tab ────────────────────────────────────────────────────────────────── */
+
+.scan-viewport {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: var(--radius-2xl);
+  background: #111;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: var(--space-4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255,255,255,0.4);
+  font-size: var(--text-sm);
+}
+
+.scan-corner {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border-color: var(--color-primary);
+  border-style: solid;
+  border-width: 0;
+}
+
+.scan-corner--tl { top: 20px; left: 20px; border-top-width: 3px; border-left-width: 3px; border-radius: var(--radius-sm) 0 0 0; }
+.scan-corner--tr { top: 20px; right: 20px; border-top-width: 3px; border-right-width: 3px; border-radius: 0 var(--radius-sm) 0 0; }
+.scan-corner--bl { bottom: 20px; left: 20px; border-bottom-width: 3px; border-left-width: 3px; border-radius: 0 0 0 var(--radius-sm); }
+.scan-corner--br { bottom: 20px; right: 20px; border-bottom-width: 3px; border-right-width: 3px; border-radius: 0 0 var(--radius-sm) 0; }
+
+.scan-line {
+  position: absolute;
+  left: 0; right: 0;
+  height: 2px;
+  background: var(--color-primary);
+  opacity: 0.8;
+  animation: scanLine 2s ease-in-out infinite;
+}
+
+@keyframes scanLine {
+  0%   { top: 20%; }
+  50%  { top: 80%; }
+  100% { top: 20%; }
+}
+
+.scan-hint {
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-4);
+}
+
+.scan-or {
+  text-align: center;
+  font-size: var(--text-xs);
+  color: var(--color-text-disabled);
+  margin: var(--space-4) 0;
+}
+
+/* ── Voice tab ───────────────────────────────────────────────────────────────── */
+
+.voice-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6);
+  padding: var(--space-6) 0;
+}
+
+.mic-ring {
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-full);
+  border: 3px solid var(--color-primary-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary-bg);
+  transition: all var(--transition-base);
+}
+
+.mic-ring--listening {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.mic-ring--listening svg { color: var(--color-surface); }
+
+.mic-ring svg { width: 36px; height: 36px; color: var(--color-primary); }
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(215, 90, 74, 0.35); }
+  50%       { box-shadow: 0 0 0 16px rgba(215, 90, 74, 0); }
+}
+
+.voice-hint {
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.voice-example {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  text-align: center;
+}
+
+.voice-parsed {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.voice-parsed__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-2);
+  text-align: center;
+}
+
+.parsed-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 10px var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+
+.parsed-row__qty {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+/* ── Manual tab ──────────────────────────────────────────────────────────────── */
+
+.autosuggest-list {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  margin-top: calc(-1 * var(--space-4));
+  margin-bottom: var(--space-4);
+}
+
+.suggest-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  transition: background var(--transition-fast);
+}
+
+.suggest-row:hover { background: var(--color-bg); }
+.suggest-row:last-child { border-bottom: none; }
+.suggest-row span:first-child { font-size: 18px; }
+
+.qty-unit-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.unit-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.unit-auto-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  background: var(--color-match-high-bg);
+  color: var(--color-match-high-text);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   PROFILE SCREEN
+══════════════════════════════════════════════════════════════════════════════ */
+
+.profile-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+}
+
+.profile-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius-full);
+  background: var(--color-secondary);
+  border: 3px solid var(--color-primary-light);
+  margin-bottom: var(--space-2);
+}
+
+.profile-name {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.profile-sub {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-3);
+  margin-bottom: var(--space-6);
+}
+
+.p-stat {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  text-align: center;
+}
+
+.p-stat__val {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.p-stat__lbl {
+  font-size: var(--text-2xs);
+  color: var(--color-text-secondary);
+  font-weight: 500;
+  margin-top: 2px;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════════
+   AUTH SCREEN
+══════════════════════════════════════════════════════════════════════════════ */
+
+.auth-screen {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-8) var(--space-6);
+  gap: var(--space-6);
+  background: var(--color-bg);
+}
+
+.auth-logo {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.auth-logo__name {
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  color: var(--color-text-primary);
+  letter-spacing: -0.5px;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 400px;
+  background: var(--color-surface);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--color-border);
+  padding: var(--space-8);
+}
+
+.auth-card__title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-1);
+}
+
+.auth-card__sub {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-6);
+}
+
+.btn-google {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: 11px var(--space-4);
+  border: 1.5px solid var(--color-border-strong);
+  border-radius: var(--radius-full);
+  background: var(--color-surface);
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  margin-bottom: var(--space-4);
+}
+
+.btn-google:hover { background: var(--color-bg); }
+
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.auth-divider__line {
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+.auth-divider__label {
+  font-size: var(--text-xs);
+  color: var(--color-text-disabled);
+  font-weight: 500;
+}
+
+.auth-toggle {
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-4);
+}
+
+.auth-toggle__btn {
+  color: var(--color-primary);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.auth-skip {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,111 @@
+/**
+ * Plated design tokens
+ *
+ * Single source of truth for all visual values.
+ * Reference: ARCHITECTURE.md + wireframes (home_screen_v2, chef_wireframes,
+ * pantry_screens_v1, saved_and_profile_v2).
+ *
+ * Rules:
+ *  - Never use a hardcoded color in a component — always use a token.
+ *  - Add tokens here when the wireframes introduce a new value.
+ *  - Semantic tokens (--color-tag-*) are preferred over raw palette tokens.
+ */
+
+:root {
+  /* ── Brand palette ─────────────────────────────────────────────────────── */
+  --color-primary:        #D75A4A;   /* coral / tomato red — CTAs, active state */
+  --color-primary-dark:   #D24735;   /* hover / pressed state */
+  --color-primary-light:  #E08074;   /* avatar ring, mic ring border */
+  --color-primary-bg:     #FAF0EF;   /* very light tint — step nums, AI badge bg */
+  --color-primary-text:   #A32D2D;   /* dark red text on primary-bg */
+
+  /* ── Secondary palette (sage green) ───────────────────────────────────── */
+  --color-secondary:      #A8B39A;   /* thumb placeholders, icons, mid match bar */
+
+  /* ── Surface / layout ──────────────────────────────────────────────────── */
+  --color-bg:             #FAF9F6;   /* warm off-white app background */
+  --color-surface:        #FFFFFF;   /* card / sheet background */
+  --color-border:         rgba(0, 0, 0, 0.10);
+  --color-border-strong:  rgba(0, 0, 0, 0.13);  /* phone frame in wireframes */
+
+  /* ── Text ──────────────────────────────────────────────────────────────── */
+  --color-text-primary:   #1A1917;   /* main body / heading text */
+  --color-text-secondary: #6B6A65;   /* muted labels, meta, placeholders */
+  --color-text-disabled:  #A8A7A2;
+
+  /* ── Pantry match — semantic ───────────────────────────────────────────── */
+  /* High ≥ 75 % */
+  --color-match-high-bar:   #639922;
+  --color-match-high-text:  #3B6D11;
+  --color-match-high-bg:    #EAF3DE;   /* "In pantry" tag background */
+
+  /* Mid  40–74 % */
+  --color-match-mid-bar:    #A8B39A;   /* same as --color-secondary */
+  --color-match-mid-text:   #5F5E5A;
+
+  /* Low  < 40 % */
+  --color-match-low-bar:    #BA7517;
+  --color-match-low-text:   #854F0B;
+  --color-match-low-bg:     #FAEEDA;   /* "Missing" tag background */
+  --color-match-low-dark:   #633806;   /* missing-banner body text */
+
+  /* ── Semantic tag colors (shorthand aliases) ───────────────────────────── */
+  --color-tag-in-pantry-bg:   var(--color-match-high-bg);
+  --color-tag-in-pantry-text: var(--color-match-high-text);
+  --color-tag-missing-bg:     var(--color-match-low-bg);
+  --color-tag-missing-text:   var(--color-match-low-text);
+
+  /* ── Toast ─────────────────────────────────────────────────────────────── */
+  --color-toast-bg:     #333333;
+  --color-toast-check:  #97C459;
+
+  /* ── Dietary note panel (Profile) ──────────────────────────────────────── */
+  --color-info-bg:      #FAF0EF;
+  --color-info-text:    #712B13;
+
+  /* ── Pantry note (Chef screen) ─────────────────────────────────────────── */
+  --color-pantry-note-bg:   #F0F4EC;
+  --color-pantry-note-text: #3B6D11;
+
+  /* ── Toggle ────────────────────────────────────────────────────────────── */
+  --color-toggle-off: #D3D1C7;
+  --color-toggle-on:  var(--color-primary);
+
+  /* ── Spacing scale ──────────────────────────────────────────────────────── */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3: 10px;
+  --space-4: 12px;
+  --space-5: 14px;
+  --space-6: 16px;
+  --space-7: 20px;
+  --space-8: 24px;
+
+  /* ── Border radius ──────────────────────────────────────────────────────── */
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   12px;
+  --radius-xl:   14px;
+  --radius-2xl:  16px;
+  --radius-3xl:  20px;
+  --radius-full: 9999px;
+
+  /* ── Typography ─────────────────────────────────────────────────────────── */
+  --text-2xs: 10px;
+  --text-xs:  11px;
+  --text-sm:  12px;
+  --text-base: 13px;
+  --text-md:  14px;
+  --text-lg:  16px;
+  --text-xl:  18px;
+  --text-2xl: 20px;
+  --text-3xl: 22px;
+
+  /* ── Layout ─────────────────────────────────────────────────────────────── */
+  --tab-height:  64px;
+  --max-width:  480px;
+
+  /* ── Transitions ────────────────────────────────────────────────────────── */
+  --transition-fast: 0.15s ease;
+  --transition-base: 0.2s ease;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,855 @@
+# Plated — Technical Architecture & Implementation Guide
+
+> **Audience:** Developer + LLM pair working together to build this project.
+> **Purpose:** Single source of truth for every structural, infrastructure, and database decision. Read this before writing any code.
+
+---
+
+## 1. What we're building
+
+Plated is a mobile-first recipe app centred on the question "What can I cook?". Users maintain a pantry of ingredients, and an AI (Google Gemini) generates recipes from what they have. Core screens: Home, Chef (AI generator), Pantry, Saved Recipes, Profile.
+
+Full UX spec lives in `product-ux-acceptance-criteria.md` and `home-saved-profile-requirements.md`. This document covers only technical decisions — architecture, data, infra, observability. When product and tech docs conflict, the product docs win on behaviour; this doc wins on implementation.
+
+---
+
+## 2. Guiding principles
+
+1. **Monorepo now, microservices later.** Everything lives in one repo with clear package boundaries so extraction into separate services requires moving code, not rewriting it.
+2. **Scalable by structure, not by premature abstraction.** No unnecessary layers. If a pattern isn't needed yet, don't add it — but name and organise files so that adding it later is obvious.
+3. **JavaScript (no TypeScript) for now.** JSDoc comments on shared interfaces are encouraged so a TS migration later is straightforward.
+4. **GCP-native hosting.** Every infrastructure choice should have a clear GCP equivalent and avoid lock-in to services that don't exist there.
+5. **Mobile web first, native app possible later.** React + React Router today. A React Native migration is feasible without a full rewrite if the state/logic layer is kept separate from the view layer.
+
+---
+
+## 3. Monorepo structure
+
+```
+plated/
+├── apps/
+│   ├── web/                  # React frontend (Vite)
+│   └── api/                  # Node.js / Express backend
+├── packages/
+│   ├── shared/               # Shared constants, validators, JSDoc types
+│   └── ui/                   # Shared React component library (design system)
+├── infra/                    # GCP / Terraform configs (added when needed)
+├── docs/                     # ARCHITECTURE.md, wireframes, requirements
+├── .github/
+│   └── workflows/            # CI/CD pipelines
+├── package.json              # Root — workspace config
+└── README.md
+```
+
+### Workspace tooling
+
+Use **npm workspaces** (built-in, no extra tooling). Root `package.json`:
+
+```json
+{
+  "name": "plated",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev": "concurrently \"npm run dev -w apps/api\" \"npm run dev -w apps/web\"",
+    "test": "npm run test --workspaces --if-present",
+    "lint": "eslint apps/ packages/ --ext .js,.jsx"
+  }
+}
+```
+
+Cross-package imports use the workspace package name, e.g. `import { UNITS } from '@plated/shared'`.
+
+---
+
+## 4. Technology choices
+
+| Layer | Choice | Rationale |
+|---|---|---|
+| Frontend framework | **React 18 + Vite** | Fast dev server, easy React Native migration path, no Next.js SSR complexity needed |
+| Routing | **React Router v6** | SPA routing, tab bar navigation, auth redirect pattern |
+| State management | **Zustand** | Lightweight, no boilerplate, easy to split by domain (pantry store, auth store, etc.) |
+| Backend | **Node.js + Express** | Simple, well-understood, easy to split into microservices later |
+| Database | **PostgreSQL** | See Section 5 |
+| ORM / query builder | **Knex.js** | Plain JS, no magic, SQL-close, easy to audit — avoids Sequelize overhead |
+| Authentication | **Firebase Authentication** | Managed Google SSO + email/password out of the box; free tier generous; GCP-native; JWT verification on backend is one library call |
+| AI / LLM | **Google AI Studio (Gemini)** | `@google/generative-ai` SDK; Gemini 1.5 Flash for cost-efficiency |
+| Voice input | **Web Speech API** (browser-native) | Zero dependency for MVP; falls back to manual input if unsupported |
+| Image / receipt scanning | **Gemini Vision** (deferred) | When barcode vs vision decision is made, Gemini multimodal handles both paths without adding a new vendor |
+| Real-time updates | **Polling via React Query** | See Section 6 |
+| Data fetching | **TanStack Query (React Query)** | Cache management, polling, loading/error states — replaces manual fetch logic |
+| Observability | **OpenTelemetry** | See Section 12 |
+| Testing | **Vitest + React Testing Library** | See Section 15 |
+| Linting | **ESLint + Prettier** | Consistent across monorepo |
+
+---
+
+## 5. Database — PostgreSQL
+
+### Why PostgreSQL over MongoDB
+
+The app's data is inherently relational: users own pantry items, recipes have ingredients, ingredients appear in pantries. A document store would require duplicating ingredient data or doing application-level joins. PostgreSQL handles this cleanly, and it's a first-class GCP product via **Cloud SQL for PostgreSQL**.
+
+For local development, run PostgreSQL via Docker (`docker-compose.yml` at root).
+
+---
+
+### Schema
+
+All tables use UUID primary keys. Timestamps are `timestamptz` (UTC). Soft deletes (`deleted_at`) are used on user-owned data so pantry changes are auditable and the "Cooked" count is append-only.
+
+---
+
+#### `users`
+
+```sql
+CREATE TABLE users (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  firebase_uid    TEXT UNIQUE NOT NULL,      -- Firebase Auth UID
+  email           TEXT UNIQUE NOT NULL,
+  display_name    TEXT,
+  city            TEXT,
+  role_label      TEXT DEFAULT 'Home cook',  -- shown in profile sub-label
+  avatar_url      TEXT,                      -- null until upload is in scope
+  cooked_count    INTEGER NOT NULL DEFAULT 0, -- append-only, never decremented
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Notes:**
+- `firebase_uid` is the lookup key on every authenticated request. Backend verifies the Firebase JWT, extracts the UID, and loads this row.
+- `cooked_count` is an append-only counter incremented on every "Cook this" action. Stored directly on the user row for fast profile reads — never decremented.
+
+---
+
+#### `dietary_preferences`
+
+```sql
+CREATE TABLE dietary_preferences (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  vegetarian      BOOLEAN NOT NULL DEFAULT FALSE,
+  gluten_free     BOOLEAN NOT NULL DEFAULT FALSE,
+  high_protein    BOOLEAN NOT NULL DEFAULT FALSE,
+  macro_tracking  BOOLEAN NOT NULL DEFAULT FALSE, -- out of scope v1, stored but unused
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id)
+);
+```
+
+One row per user, upserted on every toggle change.
+
+---
+
+#### `ingredients` (global catalogue)
+
+```sql
+CREATE TABLE ingredients (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            TEXT NOT NULL,
+  name_normalized TEXT NOT NULL,               -- lowercase, trimmed — for dedup search
+  category        TEXT NOT NULL,               -- produce | dairy | grains | protein | legumes | other
+  default_unit    TEXT NOT NULL,               -- g | ml | pcs | tsp
+  allowed_units   TEXT[] NOT NULL DEFAULT '{}', -- e.g. ['g','kg','oz','lb','cups']
+  is_countable    BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(name_normalized)
+);
+```
+
+This is a shared catalogue seeded at startup. When a user types in Manual mode or speaks in Voice mode, the app searches this table for autosuggest. New user-typed items that don't match can be added to the catalogue or stored as free-text (see `pantry_items`).
+
+---
+
+#### `pantry_items`
+
+```sql
+CREATE TABLE pantry_items (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ingredient_id   UUID REFERENCES ingredients(id),  -- null if free-text entry
+  name            TEXT NOT NULL,                    -- denormalised for display speed
+  category        TEXT NOT NULL,
+  quantity        NUMERIC(10,3) NOT NULL,
+  unit            TEXT NOT NULL,
+  added_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at      TIMESTAMPTZ                       -- soft delete
+);
+
+CREATE INDEX idx_pantry_items_user ON pantry_items(user_id) WHERE deleted_at IS NULL;
+```
+
+**Notes:**
+- `ingredient_id` is nullable to support free-text items from voice input that don't resolve to a catalogue entry.
+- Soft deletes mean "cook this" decrements are auditable. The `WHERE deleted_at IS NULL` partial index keeps active-item queries fast.
+
+---
+
+#### `recipes` (global catalogue — seeded + AI-generated)
+
+```sql
+CREATE TABLE recipes (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            TEXT NOT NULL,
+  source          TEXT NOT NULL DEFAULT 'manual',  -- 'manual' | 'chef_ai'
+  meal_type       TEXT,                            -- breakfast | lunch | dinner | snack
+  cuisine         TEXT,
+  difficulty      TEXT,                            -- easy | medium | hard
+  cook_time_mins  INTEGER,
+  servings        INTEGER,
+  is_public       BOOLEAN NOT NULL DEFAULT TRUE,   -- false = user-private Chef result pre-approval
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+---
+
+#### `recipe_ingredients`
+
+```sql
+CREATE TABLE recipe_ingredients (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_id       UUID NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+  ingredient_id   UUID REFERENCES ingredients(id), -- null if AI used a free-text ingredient
+  name            TEXT NOT NULL,                   -- denormalised
+  quantity        NUMERIC(10,3),
+  unit            TEXT,
+  sort_order      INTEGER NOT NULL DEFAULT 0
+);
+```
+
+---
+
+#### `recipe_steps`
+
+```sql
+CREATE TABLE recipe_steps (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipe_id       UUID NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+  step_number     INTEGER NOT NULL,
+  instruction     TEXT NOT NULL
+);
+```
+
+---
+
+#### `saved_recipes`
+
+```sql
+CREATE TABLE saved_recipes (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  recipe_id       UUID NOT NULL REFERENCES recipes(id) ON DELETE CASCADE,
+  is_chef_pick    BOOLEAN NOT NULL DEFAULT FALSE,   -- true if approved from Chef screen
+  saved_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at      TIMESTAMPTZ,                      -- soft delete (user deletes from Saved)
+  UNIQUE(user_id, recipe_id)
+);
+
+CREATE INDEX idx_saved_recipes_user ON saved_recipes(user_id, saved_at DESC)
+  WHERE deleted_at IS NULL;
+```
+
+---
+
+#### `chef_generations` (retry safety)
+
+```sql
+CREATE TABLE chef_generations (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  recipe_id       UUID REFERENCES recipes(id),      -- null until generation completes
+  filters         JSONB NOT NULL,                   -- {meal_type, cook_time, difficulty, cuisine, servings, notes}
+  pantry_snapshot JSONB NOT NULL,                   -- snapshot of pantry at generation time
+  status          TEXT NOT NULL DEFAULT 'pending',  -- pending | success | failed
+  retry_of        UUID REFERENCES chef_generations(id), -- chain retries
+  approved_at     TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+Powers the "Retry generates something different" guarantee — the backend checks this table to avoid repeating a `recipe_id` for the same `user_id` + `filters` session.
+
+---
+
+### Knex migrations
+
+All schema changes are managed via Knex migrations in `apps/api/db/migrations/`. Never alter a table directly — always write a migration file.
+
+```
+apps/api/
+└── db/
+    ├── knexfile.js          # env-based config
+    ├── migrations/
+    │   ├── 20240101_001_create_users.js
+    │   ├── 20240101_002_create_ingredients.js
+    │   └── ...
+    └── seeds/
+        └── ingredients.js   # seed the global ingredient catalogue
+```
+
+---
+
+## 6. Real-time updates strategy
+
+**Recommendation: React Query polling with smart invalidation.**
+
+True WebSockets add operational complexity (connection management, reconnect logic, GCP load balancer config) that isn't justified at MVP scale. Polling via React Query is simpler, GCP-friendly, and imperceptible to users at reasonable intervals.
+
+| Data | Poll interval | Notes |
+|---|---|---|
+| Pantry item count (hero card, stats) | 30s | Also invalidated immediately on any pantry mutation |
+| Saved recipe count (stats) | 30s | Also invalidated on save/delete |
+| Suggestions on Home | On tab focus | `refetchOnWindowFocus: true` in React Query |
+| Cooked count (profile) | 60s | Append-only, low urgency |
+
+**Pattern:** Mutations (Cook this, Save, Add pantry item) call `queryClient.invalidateQueries()` for the relevant keys immediately — so the UI updates instantly after a user action without waiting for the next poll. Polling is only the safety net for background changes.
+
+When you're ready to go real-time properly (WebSockets or SSE), the React Query layer makes this a swap at the data-fetching hook level without touching components.
+
+---
+
+## 7. API design
+
+### Structure
+
+REST API under `/api/v1/`. All endpoints require a Firebase JWT in `Authorization: Bearer <token>` except those marked `[public]`.
+
+```
+apps/api/
+├── src/
+│   ├── index.js              # Express app entry
+│   ├── middleware/
+│   │   ├── auth.js           # Firebase JWT verification
+│   │   ├── errorHandler.js
+│   │   └── requestLogger.js  # OpenTelemetry spans
+│   ├── routes/
+│   │   ├── auth.js           # POST /api/v1/auth/sync
+│   │   ├── pantry.js
+│   │   ├── recipes.js
+│   │   ├── chef.js
+│   │   ├── saved.js
+│   │   └── profile.js
+│   ├── services/
+│   │   ├── gemini.js         # Gemini API wrapper
+│   │   ├── pantryMatch.js    # pantry % match calculation
+│   │   └── voice.js         # voice transcript → structured items
+│   └── db/
+│       └── index.js          # Knex instance
+```
+
+### Key endpoints
+
+```
+POST   /api/v1/auth/sync              # Called once post-login: upsert user row from Firebase JWT
+GET    /api/v1/pantry                 # List user's active pantry items
+POST   /api/v1/pantry                 # Add one item
+PATCH  /api/v1/pantry/:id            # Edit quantity/unit
+DELETE /api/v1/pantry/:id            # Soft delete
+
+POST   /api/v1/pantry/voice          # Submit transcript → returns parsed items array
+POST   /api/v1/pantry/bulk           # Add multiple items at once (voice "Add all")
+
+GET    /api/v1/recipes/trending      # [public] Random selection, no auth required
+GET    /api/v1/recipes/suggestions   # Pantry-matched, ranked, auth required
+GET    /api/v1/recipes/:id           # Recipe detail with ingredients + steps
+
+POST   /api/v1/chef/generate         # Trigger Gemini generation, returns recipe
+POST   /api/v1/chef/:generationId/approve  # Approve → save to Saved
+
+GET    /api/v1/saved                 # List saved recipes (with pantry match %)
+POST   /api/v1/saved                 # Save a recipe from Home
+DELETE /api/v1/saved/:id             # Soft delete
+
+POST   /api/v1/cook                  # "Cook this" — decrement pantry + log event
+
+GET    /api/v1/profile               # Get profile + stats + preferences
+PATCH  /api/v1/profile               # Update display name, city, role
+PATCH  /api/v1/profile/preferences   # Update dietary preference toggles
+```
+
+### Error response shape
+
+All errors return:
+
+```json
+{
+  "error": {
+    "code": "PANTRY_ITEM_NOT_FOUND",
+    "message": "Pantry item not found.",
+    "status": 404
+  }
+}
+```
+
+Error codes live in `packages/shared/errors.js` so frontend and backend use the same constants.
+
+---
+
+## 8. Authentication flow
+
+**Firebase Authentication** handles credential storage, Google OAuth, and JWT issuance. The backend never stores passwords.
+
+```
+Frontend                    Backend                     Firebase
+   │                           │                           │
+   │── "Continue with Google" ─►│                           │
+   │                           │◄── OAuth flow ────────────│
+   │◄── Firebase JWT ──────────│                           │
+   │                           │                           │
+   │── POST /auth/sync ────────►│                           │
+   │   (Bearer: <JWT>)         │── verify token ──────────►│
+   │                           │◄── decoded UID ───────────│
+   │                           │── upsert users row        │
+   │◄── { user } ──────────────│                           │
+```
+
+### Frontend auth state (Zustand)
+
+```js
+// packages/ui is for components; auth state lives in apps/web/src/stores/authStore.js
+{
+  user: null | { id, email, displayName, firebaseUid },
+  token: null | string,     // Firebase ID token, refreshed automatically
+  status: 'loading' | 'authenticated' | 'unauthenticated',
+  intendedDestination: null | string  // stored before auth redirect
+}
+```
+
+### Backend middleware
+
+```js
+// apps/api/src/middleware/auth.js
+const { getAuth } = require('firebase-admin/auth');
+
+async function requireAuth(req, res, next) {
+  const token = req.headers.authorization?.split('Bearer ')[1];
+  if (!token) return res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+  const decoded = await getAuth().verifyIdToken(token);
+  req.firebaseUid = decoded.uid;
+  req.user = await db('users').where({ firebase_uid: decoded.uid }).first();
+  next();
+}
+```
+
+---
+
+## 9. AI — Gemini integration
+
+### Chef generation flow
+
+```
+Frontend                    Backend                     Gemini
+   │                           │                           │
+   │── POST /chef/generate ────►│                           │
+   │   {filters, notes}        │── build prompt ───────────►│
+   │                           │   (pantry snapshot +      │
+   │                           │    filters + preferences) │
+   │                           │◄── recipe JSON ───────────│
+   │                           │── insert recipe rows      │
+   │                           │── insert chef_generation  │
+   │◄── { generationId,        │                           │
+   │      recipe } ────────────│                           │
+```
+
+### Prompt structure (in `apps/api/src/services/gemini.js`)
+
+```js
+function buildChefPrompt({ pantryItems, filters, preferences, previousRecipeIds }) {
+  return `
+You are a recipe generator. Generate ONE recipe using primarily the ingredients listed.
+
+PANTRY INGREDIENTS:
+${pantryItems.map(i => `- ${i.name} (${i.quantity} ${i.unit})`).join('\n')}
+
+REQUIREMENTS:
+- Meal type: ${filters.mealType}
+- Cook time: ${filters.cookTime}
+- Difficulty: ${filters.difficulty}
+${filters.cuisine ? `- Cuisine: ${filters.cuisine}` : ''}
+- Servings: ${filters.servings}
+${filters.notes ? `- User notes: ${filters.notes}` : ''}
+
+DIETARY PREFERENCES (apply strictly):
+${preferences.vegetarian ? '- Vegetarian: no meat or fish' : ''}
+${preferences.glutenFree ? '- Gluten-free: no gluten-containing ingredients' : ''}
+${preferences.highProtein ? '- High protein: prioritise protein-rich ingredients' : ''}
+
+${previousRecipeIds.length ? `DO NOT generate any of these recipes again (IDs already seen this session): ${previousRecipeIds.join(', ')}` : ''}
+
+Respond ONLY with a valid JSON object in this exact shape:
+{
+  "name": "Recipe Name",
+  "cook_time_mins": 30,
+  "difficulty": "easy",
+  "servings": 2,
+  "cuisine": "Mediterranean",
+  "ingredients": [
+    { "name": "Tomatoes", "quantity": 3, "unit": "pcs", "in_pantry": true },
+    { "name": "Cumin", "quantity": 1, "unit": "tsp", "in_pantry": false }
+  ],
+  "steps": [
+    { "step_number": 1, "instruction": "Heat olive oil in a pan..." }
+  ]
+}
+`.trim();
+}
+```
+
+### Voice transcript → pantry items
+
+Also handled by Gemini (simpler model call):
+
+```js
+function buildVoiceParsePrompt(transcript) {
+  return `
+Parse this spoken ingredient list into structured JSON.
+Infer quantities and units from context (e.g. "6 eggs" → pcs, "500g of rice" → g).
+If unit cannot be inferred, default to "g" for solids, "ml" for liquids.
+
+Transcript: "${transcript}"
+
+Respond ONLY with a JSON array:
+[
+  { "name": "Eggs", "quantity": 6, "unit": "pcs" },
+  { "name": "Rice", "quantity": 500, "unit": "g" }
+]
+`.trim();
+}
+```
+
+---
+
+## 10. Voice input (MVP)
+
+### Web Speech API
+
+The browser-native `SpeechRecognition` API requires no dependencies and no server round-trip for the recording itself. The transcript is then sent to `/api/v1/pantry/voice` where Gemini parses it.
+
+```js
+// apps/web/src/hooks/useVoiceInput.js
+export function useVoiceInput({ onTranscript }) {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  // ...start(), stop(), status: 'idle' | 'listening' | 'processing'
+}
+```
+
+**Browser support note:** Chrome and Edge support this natively. Safari requires a flag. Firefox does not support it. For MVP this is acceptable — show a fallback message prompting Manual tab if unsupported. When moving to a native app, this swaps to `expo-speech` or the platform SDK.
+
+### Image / receipt scanning (deferred — architecture note)
+
+When the barcode-vs-vision decision is made, the approach is:
+
+- **Barcode only:** use `@zxing/library` (browser-based barcode decoder) + a product lookup API (Open Food Facts is free and has a large DB). No Gemini call needed.
+- **Full image / receipt:** send the image to `/api/v1/pantry/scan` where it's passed to Gemini Vision (`gemini-1.5-flash` supports multimodal). Returns the same parsed-items JSON shape as voice.
+- **Both:** the endpoint accepts either a barcode string or a base64 image and routes accordingly.
+
+The frontend Add Item UI already has the Scan tab placeholder — no structural changes needed when this ships.
+
+---
+
+## 11. Pantry match calculation
+
+The `% in pantry` value shown on recipe cards is computed server-side on the `GET /recipes/suggestions` and `GET /saved` endpoints, not client-side. This keeps the logic in one place.
+
+```js
+// apps/api/src/services/pantryMatch.js
+function calculateMatch(recipeIngredients, pantryItems) {
+  const pantryNames = new Set(
+    pantryItems.map(i => i.name.toLowerCase().trim())
+  );
+  const total = recipeIngredients.length;
+  const matched = recipeIngredients.filter(
+    i => pantryNames.has(i.name.toLowerCase().trim())
+  ).length;
+  return total === 0 ? 0 : Math.round((matched / total) * 100);
+}
+```
+
+Suggestions are ranked: `match_pct DESC, CASE WHEN meal_type = $timeOfDayMealType THEN 0 ELSE 1 END`.
+
+---
+
+## 12. Observability — OpenTelemetry
+
+### Backend instrumentation
+
+```
+apps/api/
+└── src/
+    └── telemetry.js   # OTel SDK setup — imported first in index.js
+```
+
+```js
+// apps/api/src/telemetry.js
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter({
+    url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start();
+```
+
+`getNodeAutoInstrumentations()` automatically instruments:
+- All Express HTTP requests (trace per request)
+- All `pg` / Knex database queries (trace per query)
+- `node-fetch` / `axios` outbound calls (Gemini API calls get traced)
+
+### Custom spans for business logic
+
+```js
+const { trace } = require('@opentelemetry/api');
+const tracer = trace.getTracer('plated-api');
+
+async function generateRecipe(params) {
+  return tracer.startActiveSpan('chef.generate', async (span) => {
+    span.setAttributes({
+      'user.id': params.userId,
+      'chef.meal_type': params.filters.mealType,
+      'chef.pantry_size': params.pantryItems.length,
+    });
+    try {
+      const result = await callGemini(params);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (err) {
+      span.recordException(err);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+```
+
+### GCP export target
+
+In production on GCP, export to **Google Cloud Trace** (free, native). Set:
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://cloudtrace.googleapis.com/v2
+```
+
+For local dev, run **Jaeger** via Docker (`docker-compose.yml`) and point the exporter there.
+
+### Metrics (add after traces are working)
+
+Use `@opentelemetry/sdk-metrics` to track:
+- `plated.chef.generation.duration` (histogram)
+- `plated.pantry.item_count` (gauge per user, sampled)
+- `plated.recipe.save_count` (counter)
+
+Export metrics to **Google Cloud Monitoring**.
+
+---
+
+## 13. GCP hosting plan
+
+### MVP (start here)
+
+| Component | GCP service |
+|---|---|
+| Frontend | **Cloud Run** (serve Vite build as static via `serve` or nginx container) |
+| Backend API | **Cloud Run** (Node.js container) |
+| Database | **Cloud SQL for PostgreSQL** (db-f1-micro for dev, db-g1-small for prod) |
+| Secrets | **Secret Manager** (DB password, Gemini API key, Firebase service account) |
+| Container registry | **Artifact Registry** |
+| CI/CD | **GitHub Actions** → build → push to Artifact Registry → deploy to Cloud Run |
+
+### Later (when traffic justifies it)
+
+| Component | GCP service |
+|---|---|
+| API Gateway | **Cloud Endpoints** or **API Gateway** (when microservices split happens) |
+| Background jobs | **Cloud Tasks** (async Gemini calls if response time becomes a concern) |
+| CDN | **Cloud CDN** (in front of Cloud Run for frontend) |
+| Observability | **Cloud Trace + Cloud Monitoring** (OTel already wired) |
+
+### Native app path (longer term)
+
+When ready for Google Play / App Store:
+- React → **React Native (Expo)** is the cleanest migration. Keeping business logic in hooks and Zustand stores (not components) now makes this much easier.
+- Backend is identical — same REST API, same auth.
+- Web Speech API → `expo-speech` for voice.
+- No backend changes needed for the app store submission.
+
+---
+
+## 14. Environment variables
+
+```
+# apps/api/.env
+NODE_ENV=development
+PORT=3001
+DATABASE_URL=postgresql://plated:plated@localhost:5432/plated_dev
+FIREBASE_PROJECT_ID=plated-dev
+GEMINI_API_KEY=...
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+OTEL_SERVICE_NAME=plated-api
+
+# apps/web/.env
+VITE_API_URL=http://localhost:3001
+VITE_FIREBASE_API_KEY=...
+VITE_FIREBASE_AUTH_DOMAIN=plated-dev.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=plated-dev
+```
+
+Never commit `.env` files. Use `.env.example` files with placeholder values.
+
+---
+
+## 15. Testing
+
+### Philosophy
+
+Unit test business logic and services. Integration test API routes. Don't test React component internals — test behaviour from the user's perspective.
+
+### Stack
+
+| Layer | Tool |
+|---|---|
+| Unit + integration | **Vitest** (fast, ESM-native, same config as Vite) |
+| React component | **React Testing Library** |
+| API route tests | **Supertest** + Vitest |
+| DB in tests | In-memory SQLite via Knex (same schema, swap dialect) or a dedicated test Postgres DB |
+| Test data | **@faker-js/faker** for fixtures |
+
+### File structure
+
+Co-locate tests next to the files they test:
+
+```
+apps/api/src/services/
+├── pantryMatch.js
+└── pantryMatch.test.js
+
+apps/web/src/components/
+├── RecipeCard/
+│   ├── RecipeCard.jsx
+│   └── RecipeCard.test.jsx
+```
+
+### What to test first (prioritised)
+
+1. `pantryMatch.js` — pure function, zero setup, high value
+2. `gemini.js` prompt builder — mock the API call, test the prompt output
+3. Voice parse logic — given a transcript, assert the structured output shape
+4. `POST /api/v1/cook` route — pantry decrement logic, cooked count increment, transaction integrity
+5. `POST /api/v1/chef/generate` route — mock Gemini, assert generation is stored + returned
+6. Auth middleware — valid token passes, invalid token 401s
+
+### Running tests
+
+```bash
+npm run test                    # all workspaces
+npm run test -w apps/api        # backend only
+npm run test -w apps/web        # frontend only
+npm run test -- --coverage      # with coverage report
+```
+
+---
+
+## 16. CI/CD — GitHub Actions
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: plated_test
+          POSTGRES_USER: plated
+          POSTGRES_PASSWORD: plated
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+```
+
+Deployment to Cloud Run fires on merge to `main` only (separate `deploy.yml` workflow).
+
+---
+
+## 17. Local development setup
+
+### Prerequisites
+- Node.js 20+
+- Docker Desktop (for PostgreSQL + Jaeger)
+
+### `docker-compose.yml` (at repo root)
+
+```yaml
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: plated_dev
+      POSTGRES_USER: plated
+      POSTGRES_PASSWORD: plated
+    ports: ['5432:5432']
+    volumes: ['pgdata:/var/lib/postgresql/data']
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - '16686:16686'   # Jaeger UI → http://localhost:16686
+      - '4318:4318'     # OTLP HTTP receiver
+
+volumes:
+  pgdata:
+```
+
+### First-time setup
+
+```bash
+git clone https://github.com/your-org/plated.git
+cd plated
+npm install                        # installs all workspaces
+docker compose up -d               # start postgres + jaeger
+npm run db:migrate -w apps/api     # run all migrations
+npm run db:seed -w apps/api        # seed ingredient catalogue
+npm run dev                        # starts both api + web
+```
+
+---
+
+## 18. Open decisions (log here, don't code around them)
+
+| Decision | Options | Status |
+|---|---|---|
+| Barcode vs vision scanning | Barcode (ZXing + Open Food Facts) vs Gemini Vision for full image | Undecided — architecture supports both paths |
+| Approve flow | Auto-save vs naming confirmation | Product decision pending |
+| Retry behaviour | Immediate re-generate vs filter adjustment prompt | Product decision pending |
+| Shopping list feature | Fully specced as out-of-scope v1 | Deferred |
+| Macro tracking | Toggle visible, no backend effect | Deferred |
+
+---
+
+## 19. Glossary
+
+| Term | Meaning |
+|---|---|
+| Chef | The AI recipe generation feature (and screen) |
+| Pantry | The user's stored ingredient list |
+| Generation | One Gemini call + its result, tracked in `chef_generations` |
+| Approve | User accepts a Chef result → saved to `saved_recipes` |
+| Cook this | User marks a recipe as cooked → pantry decremented, cooked count incremented |
+| Pantry match % | % of recipe ingredients that exist in the user's current pantry |
+| Firebase UID | The identifier Firebase Auth gives every user; primary join key between Firebase and our DB |

--- a/docs/chef_wireframes.html
+++ b/docs/chef_wireframes.html
@@ -1,0 +1,299 @@
+
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --primary: #D75A4A;
+    --secondary: #A8B39A;
+    --app-bg: #FAF9F6;
+    --card-bg: #FFFFFF;
+    --border: rgba(0,0,0,0.1);
+    --tab-h: 64px;
+  }
+  .wf-root {
+    display: flex; flex-direction: column; align-items: center;
+    padding: 1.5rem 0.5rem; gap: 3rem;
+    font-family: var(--font-sans, sans-serif);
+  }
+  .screen-wrap { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .screen-label {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--color-text-secondary); text-align: center;
+  }
+  .phone {
+    width: 320px; background: var(--app-bg);
+    border-radius: 28px; border: 1.5px solid rgba(0,0,0,0.13);
+    overflow: hidden; display: flex; flex-direction: column;
+  }
+  .status-bar {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 10px 20px 4px; font-size: 11px; color: var(--color-text-secondary);
+  }
+  .top-nav {
+    padding: 4px 16px 12px;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .top-nav h1 { font-size: 22px; font-weight: 500; color: var(--color-text-primary); display: flex; align-items: center; gap: 8px; }
+  .ai-badge { font-size: 11px; font-weight: 500; background: #FAF0EF; color: #A32D2D; border-radius: 20px; padding: 3px 10px; }
+  .adjust-btn { font-size: 12px; color: var(--primary); font-weight: 500; display: flex; align-items: center; gap: 4px; }
+  .content { flex: 1; padding: 0 14px; display: flex; flex-direction: column; gap: 14px; }
+  .section-label {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.07em;
+    text-transform: uppercase; color: var(--color-text-secondary); margin-bottom: -4px;
+  }
+  .card { background: var(--card-bg); border-radius: 16px; border: 0.5px solid var(--border); padding: 14px; }
+  .divider { height: 0.5px; background: var(--border); }
+
+  .result-header {
+    background: var(--primary); border-radius: 20px; padding: 16px;
+    color: white; display: flex; flex-direction: column; gap: 6px;
+  }
+  .recipe-title { font-size: 18px; font-weight: 500; }
+  .recipe-meta { font-size: 12px; opacity: 0.85; display: flex; gap: 12px; }
+  .meta-item { display: flex; align-items: center; gap: 4px; }
+  .meta-item i { font-size: 14px; }
+
+  .ingredient-list { display: flex; flex-direction: column; }
+  .ing-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 9px 0; border-bottom: 0.5px solid var(--border);
+  }
+  .ing-row:last-child { border-bottom: none; }
+  .ing-name { font-size: 13px; color: var(--color-text-primary); display: flex; align-items: center; gap: 7px; }
+  .ing-right { display: flex; align-items: center; gap: 8px; }
+  .ing-qty { font-size: 12px; color: var(--color-text-secondary); }
+  .tag-pantry { font-size: 11px; color: #3B6D11; background: #EAF3DE; border-radius: 6px; padding: 2px 7px; }
+  .tag-missing { font-size: 11px; color: #854F0B; background: #FAEEDA; border-radius: 6px; padding: 2px 7px; }
+
+  .add-list-btn {
+    display: flex; align-items: center; gap: 5px;
+    background: transparent; border: 0.5px solid rgba(186,117,23,0.4);
+    border-radius: 8px; padding: 3px 8px;
+    font-size: 11px; color: #854F0B; cursor: pointer;
+  }
+  .add-list-btn i { font-size: 13px; }
+
+  .missing-banner {
+    display: flex; align-items: center; justify-content: space-between;
+    background: #FAEEDA; border-radius: 12px; padding: 10px 12px;
+    border: 0.5px solid rgba(186,117,23,0.25);
+  }
+  .missing-left { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #633806; }
+  .missing-left i { font-size: 16px; color: #BA7517; flex-shrink: 0; }
+  .add-all-btn {
+    background: #BA7517; color: white; border: none;
+    border-radius: 8px; padding: 5px 11px; font-size: 12px; font-weight: 500;
+    white-space: nowrap; flex-shrink: 0;
+  }
+
+  .step-list { display: flex; flex-direction: column; gap: 10px; }
+  .step-row { display: flex; gap: 10px; align-items: flex-start; }
+  .step-num {
+    width: 24px; height: 24px; border-radius: 50%;
+    background: #FAF0EF; color: #A32D2D;
+    font-size: 12px; font-weight: 500;
+    display: flex; align-items: center; justify-content: center; flex-shrink: 0; margin-top: 1px;
+  }
+  .step-text { font-size: 13px; color: var(--color-text-primary); line-height: 1.5; }
+
+  .cta-row { display: flex; gap: 10px; }
+  .btn-approve {
+    flex: 1; background: var(--primary); color: white; border: none;
+    border-radius: 14px; padding: 13px; font-size: 14px; font-weight: 500;
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+  }
+  .btn-retry {
+    flex: 1; background: var(--card-bg); color: var(--color-text-primary);
+    border: 0.5px solid var(--border); border-radius: 14px; padding: 13px;
+    font-size: 14px; font-weight: 500;
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+  }
+  .approve-hint { font-size: 11px; color: var(--color-text-secondary); text-align: center; margin-top: -8px; }
+
+  .tab-bar {
+    height: var(--tab-h); background: var(--card-bg); border-top: 0.5px solid var(--border);
+    display: flex; align-items: center; justify-content: space-around; padding: 0 8px; flex-shrink: 0;
+  }
+  .tab-item { display: flex; flex-direction: column; align-items: center; gap: 3px; flex: 1; font-size: 10px; color: var(--color-text-secondary); padding: 8px 0; }
+  .tab-item i { font-size: 22px; }
+  .tab-item.active { color: var(--primary); }
+  .page-bottom { height: 10px; }
+
+  .spinner-ring {
+    width: 48px; height: 48px; border-radius: 50%;
+    border: 3px solid #FAF0EF; border-top-color: var(--primary);
+  }
+  .chips-row { display: flex; gap: 7px; flex-wrap: wrap; }
+  .chip { border-radius: 20px; padding: 6px 14px; font-size: 13px; border: 0.5px solid var(--border); background: var(--card-bg); color: var(--color-text-secondary); }
+  .chip.active { background: var(--primary); color: white; border-color: var(--primary); }
+  .fake-select { display: flex; align-items: center; justify-content: space-between; background: var(--card-bg); border: 0.5px solid var(--border); border-radius: 14px; padding: 11px 14px; font-size: 13px; color: var(--color-text-secondary); }
+  .stepper { display: flex; align-items: center; background: var(--app-bg); border-radius: 12px; border: 0.5px solid var(--border); overflow: hidden; }
+  .stepper-btn { width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; color: var(--primary); background: transparent; border: none; }
+  .stepper-val { width: 32px; text-align: center; font-size: 16px; font-weight: 500; color: var(--color-text-primary); border-left: 0.5px solid var(--border); border-right: 0.5px solid var(--border); height: 36px; line-height: 36px; }
+  .notes-field { background: var(--card-bg); border-radius: 14px; border: 0.5px solid var(--border); padding: 12px 14px; font-size: 13px; color: var(--color-text-secondary); min-height: 58px; line-height: 1.5; }
+  .chef-btn { background: var(--primary); color: white; border: none; border-radius: 16px; padding: 15px; font-size: 16px; font-weight: 500; width: 100%; display: flex; align-items: center; justify-content: center; gap: 9px; }
+  .pantry-note { display: flex; align-items: center; gap: 7px; background: #F0F4EC; border-radius: 12px; padding: 10px 12px; font-size: 12px; color: #3B6D11; }
+  .pantry-note i { font-size: 16px; color: var(--secondary); flex-shrink: 0; }
+  .notes-hint { font-size: 11px; color: var(--color-text-secondary); margin-top: -8px; padding-left: 4px; }
+</style>
+
+<div class="wf-root">
+
+  <!-- STATE 1: INPUT -->
+  <div class="screen-wrap">
+    <p class="screen-label">State 1 — Input</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav"><h1>Chef <span class="ai-badge">AI</span></h1></div>
+      <div class="content">
+        <div class="pantry-note"><i class="ti ti-basket" aria-hidden="true"></i><span>Using 14 pantry items to generate your recipe</span></div>
+        <p class="section-label">Meal type</p>
+        <div class="chips-row">
+          <div class="chip">Breakfast</div><div class="chip active">Lunch</div>
+          <div class="chip">Dinner</div><div class="chip">Snack</div>
+        </div>
+        <p class="section-label">Cook time</p>
+        <div class="chips-row">
+          <div class="chip">Under 15 min</div><div class="chip active">30 min</div><div class="chip">1 hr+</div>
+        </div>
+        <p class="section-label">Difficulty</p>
+        <div class="chips-row">
+          <div class="chip active">Easy</div><div class="chip">Medium</div><div class="chip">Hard</div>
+        </div>
+        <p class="section-label">Cuisine <span style="font-size:10px;color:var(--color-text-secondary);text-transform:none;letter-spacing:0;font-weight:400">— optional</span></p>
+        <div class="fake-select"><span>Select a cuisine…</span><i class="ti ti-chevron-down" aria-hidden="true" style="font-size:16px"></i></div>
+        <div class="divider"></div>
+        <div class="card">
+          <div style="display:flex;align-items:center;justify-content:space-between">
+            <div><div style="font-size:14px;font-weight:500;color:var(--color-text-primary)">Servings</div><div style="font-size:12px;color:var(--color-text-secondary);margin-top:2px">How many plates?</div></div>
+            <div class="stepper">
+              <button class="stepper-btn" aria-label="Decrease"><i class="ti ti-minus" aria-hidden="true" style="font-size:16px"></i></button>
+              <div class="stepper-val">2</div>
+              <button class="stepper-btn" aria-label="Increase"><i class="ti ti-plus" aria-hidden="true" style="font-size:16px"></i></button>
+            </div>
+          </div>
+        </div>
+        <p class="section-label">Extra notes <span style="font-size:10px;color:var(--color-text-secondary);text-transform:none;letter-spacing:0;font-weight:400">— optional</span></p>
+        <div class="notes-field">e.g. make it spicy, no cilantro, high protein…</div>
+        <p class="notes-hint">Chef will figure out the rest</p>
+        <button class="chef-btn"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:18px"></i> Chef it</button>
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item active"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- STATE 2: GENERATING -->
+  <div class="screen-wrap">
+    <p class="screen-label">State 2 — Generating</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav"><h1>Chef <span class="ai-badge">AI</span></h1></div>
+      <div class="content" style="align-items:center;justify-content:center;padding-bottom:80px">
+        <div class="spinner-ring"></div>
+        <div style="font-size:14px;color:var(--color-text-secondary);text-align:center;margin-top:12px">Chef is cooking…</div>
+        <div style="font-size:12px;color:var(--color-text-secondary);opacity:0.7;text-align:center;margin-top:4px">Finding the best recipe from your pantry</div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item active"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- STATE 3: RESULT -->
+  <div class="screen-wrap">
+    <p class="screen-label">State 3 — Result</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Chef <span class="ai-badge">AI</span></h1>
+        <div class="adjust-btn"><i class="ti ti-adjustments-horizontal" aria-hidden="true" style="font-size:16px"></i> Adjust</div>
+      </div>
+      <div class="content">
+
+        <div class="result-header">
+          <div class="recipe-title">Spiced Tomato &amp; Feta Shakshuka</div>
+          <div class="recipe-meta">
+            <div class="meta-item"><i class="ti ti-clock" aria-hidden="true"></i> 30 min</div>
+            <div class="meta-item"><i class="ti ti-chef-hat" aria-hidden="true"></i> Easy</div>
+            <div class="meta-item"><i class="ti ti-users" aria-hidden="true"></i> 2 servings</div>
+          </div>
+        </div>
+
+        <!-- Missing ingredients banner -->
+        <div class="missing-banner">
+          <div class="missing-left">
+            <i class="ti ti-shopping-cart" aria-hidden="true"></i>
+            <span>1 ingredient missing from your pantry</span>
+          </div>
+          <button class="add-all-btn">Add to list</button>
+        </div>
+
+        <p class="section-label">Ingredients</p>
+        <div class="card" style="padding: 4px 14px;">
+          <div class="ingredient-list">
+            <div class="ing-row">
+              <div class="ing-name"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i> Tomatoes</div>
+              <div class="ing-right"><span class="ing-qty">3 pcs</span><span class="tag-pantry">In pantry</span></div>
+            </div>
+            <div class="ing-row">
+              <div class="ing-name"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i> Eggs</div>
+              <div class="ing-right"><span class="ing-qty">4 pcs</span><span class="tag-pantry">In pantry</span></div>
+            </div>
+            <div class="ing-row">
+              <div class="ing-name"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i> Feta cheese</div>
+              <div class="ing-right"><span class="ing-qty">80 g</span><span class="tag-pantry">In pantry</span></div>
+            </div>
+            <div class="ing-row">
+              <div class="ing-name"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i> Garlic</div>
+              <div class="ing-right"><span class="ing-qty">2 cloves</span><span class="tag-pantry">In pantry</span></div>
+            </div>
+            <div class="ing-row">
+              <div class="ing-name"><i class="ti ti-alert-circle" aria-hidden="true" style="color:#BA7517"></i> Cumin</div>
+              <div class="ing-right">
+                <span class="ing-qty">1 tsp</span>
+                <span class="tag-missing">Missing</span>
+                <button class="add-list-btn" aria-label="Add cumin to shopping list"><i class="ti ti-circle-plus" aria-hidden="true"></i> Add</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p class="section-label">Steps</p>
+        <div class="card">
+          <div class="step-list">
+            <div class="step-row"><div class="step-num">1</div><div class="step-text">Heat olive oil in a pan over medium heat. Sauté garlic and onion until soft.</div></div>
+            <div class="step-row"><div class="step-num">2</div><div class="step-text">Add crushed tomatoes and spices. Simmer for 10 minutes until thickened.</div></div>
+            <div class="step-row"><div class="step-num">3</div><div class="step-text">Create wells in the sauce and crack eggs in. Cover and cook 5–7 min.</div></div>
+            <div class="step-row"><div class="step-num">4</div><div class="step-text">Crumble feta on top and serve straight from the pan.</div></div>
+          </div>
+        </div>
+
+        <div class="cta-row">
+          <button class="btn-approve"><i class="ti ti-check" aria-hidden="true" style="font-size:16px"></i> Approve</button>
+          <button class="btn-retry"><i class="ti ti-refresh" aria-hidden="true" style="font-size:16px"></i> Retry</button>
+        </div>
+        <p class="approve-hint">Approving saves this recipe to your collection</p>
+
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item active"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/docs/home_screen_v2.html
+++ b/docs/home_screen_v2.html
@@ -1,0 +1,276 @@
+
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --primary: #D75A4A; --primary-dark: #D24735; --secondary: #A8B39A;
+    --app-bg: #FAF9F6; --card-bg: #FFFFFF; --border: rgba(0,0,0,0.1); --tab-h: 64px;
+  }
+  .wf-root { display:flex; flex-direction:column; align-items:center; padding:1.5rem 0.5rem; gap:3rem; font-family:var(--font-sans,sans-serif); }
+  .screen-wrap { display:flex; flex-direction:column; align-items:center; gap:8px; }
+  .screen-label { font-size:11px; font-weight:500; letter-spacing:0.08em; text-transform:uppercase; color:var(--color-text-secondary); text-align:center; }
+  .phone { width:320px; background:var(--app-bg); border-radius:28px; border:1.5px solid rgba(0,0,0,0.13); overflow:hidden; display:flex; flex-direction:column; }
+  .status-bar { display:flex; justify-content:space-between; align-items:center; padding:10px 20px 4px; font-size:11px; color:var(--color-text-secondary); }
+  .top-nav { padding:4px 16px 12px; display:flex; align-items:center; justify-content:space-between; }
+  .top-nav h1 { font-size:20px; font-weight:500; color:var(--color-text-primary); }
+  .content { flex:1; padding:0 14px; display:flex; flex-direction:column; gap:14px; }
+  .section-label { font-size:11px; font-weight:500; letter-spacing:0.07em; text-transform:uppercase; color:var(--color-text-secondary); margin-bottom:-4px; }
+  .card { background:var(--card-bg); border-radius:16px; border:0.5px solid var(--border); padding:14px; }
+  .divider { height:0.5px; background:var(--border); }
+  .page-bottom { height:10px; }
+  .tab-bar { height:var(--tab-h); background:var(--card-bg); border-top:0.5px solid var(--border); display:flex; align-items:center; justify-content:space-around; padding:0 8px; flex-shrink:0; }
+  .tab-item { display:flex; flex-direction:column; align-items:center; gap:3px; flex:1; font-size:10px; color:var(--color-text-secondary); padding:8px 0; }
+  .tab-item i { font-size:22px; }
+  .tab-item.active { color:var(--primary); }
+
+  .hero-card { background:var(--primary); border-radius:20px; padding:16px; color:white; }
+  .hero-card h2 { font-size:17px; font-weight:500; margin-bottom:4px; }
+  .hero-card p { font-size:13px; opacity:0.85; }
+  .hero-cta { margin-top:14px; background:white; color:#A32D2D; border:none; border-radius:12px; padding:9px 18px; font-size:13px; font-weight:500; display:inline-flex; align-items:center; gap:6px; }
+
+  .stats-row { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+  .stat-card { background:var(--card-bg); border-radius:14px; border:0.5px solid var(--border); padding:12px; display:flex; flex-direction:column; gap:4px; }
+  .stat-icon { font-size:20px; color:var(--secondary); margin-bottom:2px; }
+  .stat-val { font-size:22px; font-weight:500; color:var(--color-text-primary); }
+  .stat-lbl { font-size:11px; color:var(--color-text-secondary); }
+
+  .suggestion-card { background:var(--card-bg); border-radius:16px; border:0.5px solid var(--border); overflow:hidden; cursor:pointer; }
+  .suggestion-row { display:flex; align-items:center; gap:12px; padding:12px 14px; }
+  .suggestion-thumb { width:48px; height:48px; border-radius:12px; background:var(--secondary); opacity:0.3; flex-shrink:0; }
+  .suggestion-info { flex:1; }
+  .suggestion-name { font-size:14px; font-weight:500; color:var(--color-text-primary); }
+  .suggestion-meta { font-size:12px; color:var(--color-text-secondary); margin-top:2px; display:flex; align-items:center; gap:6px; }
+  .suggestion-meta i { font-size:13px; }
+  .match-pill { font-size:11px; font-weight:500; background:#EAF3DE; color:#3B6D11; border-radius:8px; padding:3px 8px; flex-shrink:0; }
+  .suggestion-divider { height:0.5px; background:var(--border); margin:0 14px; }
+
+  .expanded-card { background:var(--card-bg); border-radius:16px; border:2px solid var(--primary); overflow:hidden; }
+  .expanded-header { background:var(--primary); padding:14px; color:white; }
+  .expanded-title { font-size:16px; font-weight:500; margin-bottom:5px; color:white; }
+  .expanded-meta { display:flex; gap:12px; font-size:12px; opacity:0.85; }
+  .expanded-meta-item { display:flex; align-items:center; gap:4px; }
+  .expanded-meta-item i { font-size:13px; }
+  .match-bar-wrap { display:flex; align-items:center; gap:8px; padding:8px 14px; border-bottom:0.5px solid var(--border); }
+  .match-bar-bg { flex:1; height:5px; background:#F0F0ED; border-radius:3px; overflow:hidden; }
+  .match-bar-fill { height:100%; border-radius:3px; background:#639922; }
+  .match-pct { font-size:11px; font-weight:500; color:#3B6D11; white-space:nowrap; }
+
+  .expanded-body { padding:12px 14px; display:flex; flex-direction:column; gap:11px; }
+  .ing-row-sm { display:flex; align-items:center; justify-content:space-between; padding:7px 0; border-bottom:0.5px solid var(--border); font-size:12px; }
+  .ing-row-sm:last-child { border-bottom:none; }
+  .ing-left { display:flex; align-items:center; gap:6px; color:var(--color-text-primary); }
+  .ing-left i { font-size:13px; }
+  .ing-right-sm { display:flex; align-items:center; gap:6px; color:var(--color-text-secondary); }
+  .tag-pantry-sm { font-size:10px; color:#3B6D11; background:#EAF3DE; border-radius:5px; padding:2px 6px; }
+  .tag-missing-sm { font-size:10px; color:#854F0B; background:#FAEEDA; border-radius:5px; padding:2px 6px; }
+  .step-row-sm { display:flex; gap:9px; align-items:flex-start; }
+  .step-num-sm { width:20px; height:20px; border-radius:50%; background:#FAF0EF; color:#A32D2D; font-size:11px; font-weight:500; display:flex; align-items:center; justify-content:center; flex-shrink:0; margin-top:1px; }
+  .step-text-sm { font-size:12px; color:var(--color-text-primary); line-height:1.5; }
+
+  .cta-pair { display:flex; gap:8px; }
+  .btn-cook { flex:1; background:var(--primary); color:white; border:none; border-radius:12px; padding:12px 10px; font-size:13px; font-weight:500; display:flex; align-items:center; justify-content:center; gap:6px; }
+  .btn-save { flex:1; background:var(--card-bg); color:#A32D2D; border:1.5px solid rgba(215,90,74,0.4); border-radius:12px; padding:12px 10px; font-size:13px; font-weight:500; display:flex; align-items:center; justify-content:center; gap:6px; }
+
+  .toast { background:#333; color:white; border-radius:12px; padding:10px 14px; font-size:12px; display:flex; align-items:center; gap:8px; margin-bottom:2px; }
+  .toast i { font-size:16px; color:#97C459; }
+  .notif-dot { width:8px; height:8px; border-radius:50%; background:var(--primary); border:1.5px solid white; position:absolute; top:6px; right:6px; }
+  .nav-icon { width:36px; height:36px; border-radius:50%; background:var(--card-bg); border:0.5px solid var(--border); display:flex; align-items:center; justify-content:center; color:var(--color-text-secondary); font-size:18px; position:relative; }
+</style>
+
+<div class="wf-root">
+
+  <!-- HOME — DEFAULT -->
+  <div class="screen-wrap">
+    <p class="screen-label">Home — Default</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Good morning, Jamie</h1>
+        <div class="nav-icon"><i class="ti ti-bell" aria-hidden="true"></i></div>
+      </div>
+      <div class="content">
+        <div class="hero-card">
+          <h2>What can I cook today?</h2>
+          <p>You have 14 items in your pantry. Let Chef find something delicious.</p>
+          <button class="hero-cta"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:15px"></i> Open Chef</button>
+        </div>
+        <div class="stats-row">
+          <div class="stat-card">
+            <i class="ti ti-basket stat-icon" aria-hidden="true"></i>
+            <span class="stat-val">14</span>
+            <span class="stat-lbl">Pantry items</span>
+          </div>
+          <div class="stat-card">
+            <i class="ti ti-bookmark stat-icon" aria-hidden="true"></i>
+            <span class="stat-val">8</span>
+            <span class="stat-lbl">Saved recipes</span>
+          </div>
+        </div>
+        <p class="section-label">Suggested for you</p>
+        <div class="suggestion-card">
+          <div class="suggestion-row">
+            <div class="suggestion-thumb"></div>
+            <div class="suggestion-info">
+              <div class="suggestion-name">Shakshuka</div>
+              <div class="suggestion-meta"><i class="ti ti-clock" aria-hidden="true"></i>25 min · Easy</div>
+            </div>
+            <span class="match-pill">94% match</span>
+          </div>
+          <div class="suggestion-divider"></div>
+          <div class="suggestion-row">
+            <div class="suggestion-thumb"></div>
+            <div class="suggestion-info">
+              <div class="suggestion-name">Pasta Aglio e Olio</div>
+              <div class="suggestion-meta"><i class="ti ti-clock" aria-hidden="true"></i>15 min · Easy</div>
+            </div>
+            <span class="match-pill">87% match</span>
+          </div>
+          <div class="suggestion-divider"></div>
+          <div class="suggestion-row">
+            <div class="suggestion-thumb"></div>
+            <div class="suggestion-info">
+              <div class="suggestion-name">Veggie Stir Fry</div>
+              <div class="suggestion-meta"><i class="ti ti-clock" aria-hidden="true"></i>20 min · Medium</div>
+            </div>
+            <span class="match-pill">80% match</span>
+          </div>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item active"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- HOME — EXPANDED RECIPE CARD -->
+  <div class="screen-wrap">
+    <p class="screen-label">Home — Recipe card expanded</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Good morning, Jamie</h1>
+        <div class="nav-icon"><i class="ti ti-bell" aria-hidden="true"></i></div>
+      </div>
+      <div class="content">
+        <div class="hero-card">
+          <h2>What can I cook today?</h2>
+          <p>You have 14 items in your pantry. Let Chef find something delicious.</p>
+          <button class="hero-cta"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:15px"></i> Open Chef</button>
+        </div>
+        <p class="section-label">Suggested for you</p>
+
+        <div class="expanded-card">
+          <div class="expanded-header">
+            <div class="expanded-title">Shakshuka</div>
+            <div class="expanded-meta">
+              <div class="expanded-meta-item"><i class="ti ti-clock" aria-hidden="true"></i>25 min</div>
+              <div class="expanded-meta-item"><i class="ti ti-chef-hat" aria-hidden="true"></i>Easy</div>
+              <div class="expanded-meta-item"><i class="ti ti-users" aria-hidden="true"></i>2 servings</div>
+            </div>
+          </div>
+          <div class="match-bar-wrap">
+            <div class="match-bar-bg"><div class="match-bar-fill" style="width:94%"></div></div>
+            <span class="match-pct">94% in pantry</span>
+          </div>
+          <div class="expanded-body">
+            <p class="section-label">Ingredients</p>
+            <div style="background:var(--app-bg);border-radius:12px;padding:2px 10px;">
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Tomatoes</div><div class="ing-right-sm"><span>3 pcs</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Eggs</div><div class="ing-right-sm"><span>4 pcs</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Feta</div><div class="ing-right-sm"><span>80 g</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-alert-circle" aria-hidden="true" style="color:#BA7517"></i>Cumin</div><div class="ing-right-sm"><span>1 tsp</span><span class="tag-missing-sm">Missing</span></div></div>
+            </div>
+            <p class="section-label">Steps</p>
+            <div style="display:flex;flex-direction:column;gap:8px;">
+              <div class="step-row-sm"><div class="step-num-sm">1</div><div class="step-text-sm">Heat olive oil. Sauté garlic and onion until soft.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">2</div><div class="step-text-sm">Add tomatoes and spices. Simmer 10 min.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">3</div><div class="step-text-sm">Create wells, crack eggs in. Cover 5–7 min.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">4</div><div class="step-text-sm">Crumble feta on top and serve from the pan.</div></div>
+            </div>
+            <div class="cta-pair">
+              <button class="btn-cook"><i class="ti ti-chef-hat" aria-hidden="true" style="font-size:15px"></i> Cook this</button>
+              <button class="btn-save"><i class="ti ti-bookmark" aria-hidden="true" style="font-size:15px"></i> Save</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item active"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- HOME — POST COOK THIS (toast) -->
+  <div class="screen-wrap">
+    <p class="screen-label">Home — After "Cook this" (toast)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Good morning, Jamie</h1>
+        <div class="nav-icon"><i class="ti ti-bell" aria-hidden="true"></i></div>
+      </div>
+      <div class="content">
+        <div class="toast">
+          <i class="ti ti-circle-check" aria-hidden="true"></i>
+          <span>Cooked! Removed 4 ingredients from your pantry.</span>
+        </div>
+        <div class="hero-card">
+          <h2>What can I cook today?</h2>
+          <p>You have 10 items in your pantry. Let Chef find something delicious.</p>
+          <button class="hero-cta"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:15px"></i> Open Chef</button>
+        </div>
+        <div class="stats-row">
+          <div class="stat-card">
+            <i class="ti ti-basket stat-icon" aria-hidden="true"></i>
+            <span class="stat-val">10</span>
+            <span class="stat-lbl">Pantry items</span>
+          </div>
+          <div class="stat-card">
+            <i class="ti ti-bookmark stat-icon" aria-hidden="true"></i>
+            <span class="stat-val">8</span>
+            <span class="stat-lbl">Saved recipes</span>
+          </div>
+        </div>
+        <p class="section-label">Suggested for you</p>
+        <div class="suggestion-card">
+          <div class="suggestion-row">
+            <div class="suggestion-thumb"></div>
+            <div class="suggestion-info">
+              <div class="suggestion-name">Pasta Aglio e Olio</div>
+              <div class="suggestion-meta"><i class="ti ti-clock" aria-hidden="true"></i>15 min · Easy</div>
+            </div>
+            <span class="match-pill">87% match</span>
+          </div>
+          <div class="suggestion-divider"></div>
+          <div class="suggestion-row">
+            <div class="suggestion-thumb"></div>
+            <div class="suggestion-info">
+              <div class="suggestion-name">Veggie Stir Fry</div>
+              <div class="suggestion-meta"><i class="ti ti-clock" aria-hidden="true"></i>20 min · Medium</div>
+            </div>
+            <span class="match-pill">80% match</span>
+          </div>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item active"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/docs/pantry_screens_v1.html
+++ b/docs/pantry_screens_v1.html
@@ -1,0 +1,462 @@
+
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --primary: #D75A4A;
+    --primary-dark: #D24735;
+    --secondary: #A8B39A;
+    --app-bg: #FAF9F6;
+    --card-bg: #FFFFFF;
+    --border: rgba(0,0,0,0.1);
+    --tab-h: 64px;
+  }
+  .wf-root {
+    display: flex; flex-direction: column; align-items: center;
+    padding: 1.5rem 0.5rem; gap: 3rem;
+    font-family: var(--font-sans, sans-serif);
+  }
+  .screen-wrap { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+  .screen-label {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--color-text-secondary); text-align: center;
+  }
+  .phone {
+    width: 320px; background: var(--app-bg);
+    border-radius: 28px; border: 1.5px solid rgba(0,0,0,0.13);
+    overflow: hidden; display: flex; flex-direction: column;
+  }
+  .status-bar {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 10px 20px 4px; font-size: 11px; color: var(--color-text-secondary);
+  }
+  .top-nav {
+    padding: 4px 16px 12px;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .top-nav h1 { font-size: 22px; font-weight: 500; color: var(--color-text-primary); }
+  .content { flex: 1; padding: 0 14px; display: flex; flex-direction: column; gap: 14px; }
+  .section-label {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.07em;
+    text-transform: uppercase; color: var(--color-text-secondary); margin-bottom: -4px;
+  }
+  .card { background: var(--card-bg); border-radius: 16px; border: 0.5px solid var(--border); padding: 14px; }
+  .divider { height: 0.5px; background: var(--border); }
+  .tab-bar {
+    height: var(--tab-h); background: var(--card-bg); border-top: 0.5px solid var(--border);
+    display: flex; align-items: center; justify-content: space-around; padding: 0 8px; flex-shrink: 0;
+  }
+  .tab-item { display: flex; flex-direction: column; align-items: center; gap: 3px; flex: 1; font-size: 10px; color: var(--color-text-secondary); padding: 8px 0; }
+  .tab-item i { font-size: 22px; }
+  .tab-item.active { color: var(--primary); }
+  .page-bottom { height: 10px; }
+
+  /* Pantry main */
+  .search-bar {
+    display: flex; align-items: center; gap: 8px;
+    background: var(--card-bg); border: 0.5px solid var(--border);
+    border-radius: 14px; padding: 10px 14px;
+    color: var(--color-text-secondary); font-size: 13px;
+  }
+  .chips-row { display: flex; gap: 7px; flex-wrap: wrap; }
+  .chip { border-radius: 20px; padding: 6px 14px; font-size: 13px; border: 0.5px solid var(--border); background: var(--card-bg); color: var(--color-text-secondary); }
+  .chip.active { background: var(--primary); color: white; border-color: var(--primary); }
+  .cat-row { display: flex; align-items: center; justify-content: space-between; }
+  .cat-name { font-size: 11px; font-weight: 500; letter-spacing: 0.07em; text-transform: uppercase; color: var(--color-text-secondary); }
+  .ing-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+  .ing-tile { background: var(--card-bg); border: 0.5px solid var(--border); border-radius: 14px; padding: 10px 12px; display: flex; align-items: center; gap: 8px; }
+  .ing-icon { width: 32px; height: 32px; border-radius: 10px; background: var(--secondary); opacity: 0.3; flex-shrink: 0; }
+  .ing-name { font-size: 13px; font-weight: 500; color: var(--color-text-primary); }
+  .ing-qty { font-size: 11px; color: var(--color-text-secondary); }
+  .fab {
+    position: absolute; bottom: calc(var(--tab-h) + 14px); right: 14px;
+    width: 48px; height: 48px; border-radius: 50%;
+    background: var(--primary); color: white;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 22px; border: none;
+  }
+
+  /* Full-screen add flow */
+  .fs-nav {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 4px 16px 12px;
+  }
+  .fs-nav .back-btn { display: flex; align-items: center; gap: 6px; font-size: 14px; color: var(--primary); font-weight: 500; }
+  .fs-nav h1 { font-size: 18px; font-weight: 500; color: var(--color-text-primary); }
+  .fs-nav .spacer { width: 60px; }
+
+  /* Method tabs */
+  .method-tabs {
+    display: flex; background: var(--card-bg); border-radius: 14px;
+    border: 0.5px solid var(--border); padding: 4px; gap: 2px;
+  }
+  .method-tab {
+    flex: 1; display: flex; flex-direction: column; align-items: center;
+    gap: 4px; padding: 8px 4px; border-radius: 10px;
+    font-size: 11px; color: var(--color-text-secondary);
+  }
+  .method-tab i { font-size: 20px; }
+  .method-tab.active { background: var(--primary); color: white; }
+
+  /* Scan state */
+  .scan-viewport {
+    background: #1A1A1A; border-radius: 16px;
+    height: 190px; position: relative;
+    display: flex; align-items: center; justify-content: center; overflow: hidden;
+  }
+  .scan-corner {
+    position: absolute; width: 28px; height: 28px;
+    border-color: white; border-style: solid; opacity: 0.8;
+  }
+  .scan-corner.tl { top: 20px; left: 20px; border-width: 3px 0 0 3px; border-radius: 4px 0 0 0; }
+  .scan-corner.tr { top: 20px; right: 20px; border-width: 3px 3px 0 0; border-radius: 0 4px 0 0; }
+  .scan-corner.bl { bottom: 20px; left: 20px; border-width: 0 0 3px 3px; border-radius: 0 0 0 4px; }
+  .scan-corner.br { bottom: 20px; right: 20px; border-width: 0 3px 3px 0; border-radius: 0 0 4px 0; }
+  .scan-line {
+    position: absolute; left: 20px; right: 20px; height: 1.5px;
+    background: var(--primary); opacity: 0.8; top: 50%;
+  }
+  .scan-hint { font-size: 12px; color: rgba(255,255,255,0.6); text-align: center; margin-top: 4px; }
+  .scan-or {
+    display: flex; align-items: center; gap: 10px;
+    font-size: 12px; color: var(--color-text-secondary);
+  }
+  .scan-or-line { flex: 1; height: 0.5px; background: var(--border); }
+  .manual-trigger {
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+    background: var(--card-bg); border: 0.5px solid var(--border);
+    border-radius: 14px; padding: 12px; font-size: 13px;
+    color: var(--color-text-secondary); width: 100%;
+  }
+
+  /* Voice state */
+  .voice-area {
+    display: flex; flex-direction: column; align-items: center;
+    gap: 14px; padding: 8px 0 4px;
+  }
+  .mic-ring {
+    width: 80px; height: 80px; border-radius: 50%;
+    background: #FAF0EF; border: 2px solid #E08074;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .mic-ring i { font-size: 34px; color: var(--primary); }
+  .voice-hint { font-size: 13px; color: var(--color-text-secondary); text-align: center; line-height: 1.5; }
+  .voice-example {
+    background: var(--card-bg); border-radius: 12px; border: 0.5px solid var(--border);
+    padding: 10px 14px; font-size: 12px; color: var(--color-text-secondary);
+    font-style: italic; text-align: center; width: 100%;
+  }
+  .voice-parsed {
+    width: 100%; display: flex; flex-direction: column; gap: 8px;
+  }
+  .parsed-row {
+    display: flex; align-items: center; justify-content: space-between;
+    background: var(--card-bg); border-radius: 12px; border: 0.5px solid var(--border);
+    padding: 10px 12px;
+  }
+  .parsed-name { font-size: 13px; font-weight: 500; color: var(--color-text-primary); display: flex; align-items: center; gap: 7px; }
+  .parsed-name i { font-size: 14px; color: #3B6D11; }
+  .parsed-qty { font-size: 12px; color: var(--color-text-secondary); }
+  .voice-add-btn {
+    background: var(--primary); color: white; border: none;
+    border-radius: 14px; padding: 13px; font-size: 14px; font-weight: 500;
+    width: 100%; display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+
+  /* Manual state */
+  .form-field { display: flex; flex-direction: column; gap: 5px; }
+  .form-label { font-size: 12px; font-weight: 500; color: var(--color-text-secondary); }
+  .form-input {
+    background: var(--card-bg); border: 0.5px solid var(--border);
+    border-radius: 12px; padding: 11px 14px;
+    font-size: 13px; color: var(--color-text-secondary);
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .autosuggest-list {
+    background: var(--card-bg); border: 0.5px solid var(--border);
+    border-radius: 12px; overflow: hidden; margin-top: -8px;
+  }
+  .suggest-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 14px; border-bottom: 0.5px solid var(--border);
+  }
+  .suggest-row:last-child { border-bottom: none; }
+  .suggest-icon { width: 28px; height: 28px; border-radius: 8px; background: var(--secondary); opacity: 0.3; flex-shrink: 0; }
+  .suggest-name { font-size: 13px; color: var(--color-text-primary); }
+  .suggest-cat { font-size: 11px; color: var(--color-text-secondary); }
+
+  /* Qty + unit row */
+  .qty-unit-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .unit-selector {
+    background: var(--card-bg); border: 0.5px solid var(--border);
+    border-radius: 12px; padding: 11px 14px;
+    font-size: 13px; color: var(--color-text-primary);
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .unit-auto-badge {
+    font-size: 10px; background: #EAF3DE; color: #3B6D11;
+    border-radius: 6px; padding: 2px 6px; margin-left: 4px;
+  }
+  .add-item-btn {
+    background: var(--primary); color: white; border: none;
+    border-radius: 14px; padding: 13px; font-size: 14px; font-weight: 500;
+    width: 100%; display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+  .cat-selector { display: flex; gap: 7px; flex-wrap: wrap; }
+  .cat-chip { border-radius: 20px; padding: 5px 13px; font-size: 12px; border: 0.5px solid var(--border); background: var(--card-bg); color: var(--color-text-secondary); }
+  .cat-chip.active { background: var(--secondary); color: white; border-color: var(--secondary); }
+</style>
+
+<div class="wf-root">
+
+  <!-- PANTRY MAIN -->
+  <div class="screen-wrap">
+    <p class="screen-label">Pantry — Main view</p>
+    <div class="phone" style="position:relative">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1 style="font-size:22px;font-weight:500;color:var(--color-text-primary)">My pantry</h1>
+        <div style="font-size:12px;color:var(--color-text-secondary)">14 items</div>
+      </div>
+      <div class="content">
+        <div class="search-bar"><i class="ti ti-search" aria-hidden="true"></i><span>Search ingredients…</span></div>
+        <div class="chips-row">
+          <div class="chip active">All</div>
+          <div class="chip">Produce</div>
+          <div class="chip">Dairy</div>
+          <div class="chip">Grains</div>
+          <div class="chip">Protein</div>
+        </div>
+        <div class="cat-row"><span class="cat-name">Produce</span></div>
+        <div class="ing-grid">
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Tomatoes</div><div class="ing-qty">3 pcs</div></div></div>
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Spinach</div><div class="ing-qty">100 g</div></div></div>
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Garlic</div><div class="ing-qty">6 cloves</div></div></div>
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Onion</div><div class="ing-qty">2 pcs</div></div></div>
+        </div>
+        <div class="cat-row"><span class="cat-name">Dairy</span></div>
+        <div class="ing-grid">
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Eggs</div><div class="ing-qty">6 pcs</div></div></div>
+          <div class="ing-tile"><div class="ing-icon"></div><div><div class="ing-name">Feta</div><div class="ing-qty">200 g</div></div></div>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+      <button class="fab" aria-label="Add ingredient"><i class="ti ti-plus" aria-hidden="true"></i></button>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item active"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADD SCREEN — SCAN TAB -->
+  <div class="screen-wrap">
+    <p class="screen-label">Add item — Scan (default)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="fs-nav">
+        <div class="back-btn"><i class="ti ti-arrow-left" aria-hidden="true" style="font-size:18px"></i> Pantry</div>
+        <h1>Add item</h1>
+        <div class="spacer"></div>
+      </div>
+      <div class="content">
+        <div class="method-tabs">
+          <div class="method-tab active"><i class="ti ti-scan" aria-hidden="true"></i>Scan</div>
+          <div class="method-tab"><i class="ti ti-microphone" aria-hidden="true"></i>Voice</div>
+          <div class="method-tab"><i class="ti ti-pencil" aria-hidden="true"></i>Manual</div>
+        </div>
+        <div class="scan-viewport">
+          <div class="scan-corner tl"></div>
+          <div class="scan-corner tr"></div>
+          <div class="scan-corner bl"></div>
+          <div class="scan-corner br"></div>
+          <div class="scan-line"></div>
+        </div>
+        <p class="scan-hint">Point your camera at a barcode or food label</p>
+        <div class="scan-or">
+          <div class="scan-or-line"></div>
+          <span>or add manually</span>
+          <div class="scan-or-line"></div>
+        </div>
+        <button class="manual-trigger">
+          <i class="ti ti-pencil" aria-hidden="true" style="font-size:17px"></i>
+          Type an ingredient instead
+        </button>
+        <div class="page-bottom"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADD SCREEN — VOICE TAB (listening) -->
+  <div class="screen-wrap">
+    <p class="screen-label">Add item — Voice (listening)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="fs-nav">
+        <div class="back-btn"><i class="ti ti-arrow-left" aria-hidden="true" style="font-size:18px"></i> Pantry</div>
+        <h1>Add item</h1>
+        <div class="spacer"></div>
+      </div>
+      <div class="content">
+        <div class="method-tabs">
+          <div class="method-tab"><i class="ti ti-scan" aria-hidden="true"></i>Scan</div>
+          <div class="method-tab active"><i class="ti ti-microphone" aria-hidden="true"></i>Voice</div>
+          <div class="method-tab"><i class="ti ti-pencil" aria-hidden="true"></i>Manual</div>
+        </div>
+        <div class="voice-area">
+          <div class="mic-ring"><i class="ti ti-microphone" aria-hidden="true"></i></div>
+          <p class="voice-hint">Tap the mic and say your ingredients.<br>You can list multiple at once.</p>
+          <div class="voice-example">"6 eggs, 500g of rice, 2 onions, 1L of milk"</div>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADD SCREEN — VOICE TAB (parsed result) -->
+  <div class="screen-wrap">
+    <p class="screen-label">Add item — Voice (parsed)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="fs-nav">
+        <div class="back-btn"><i class="ti ti-arrow-left" aria-hidden="true" style="font-size:18px"></i> Pantry</div>
+        <h1>Add item</h1>
+        <div class="spacer"></div>
+      </div>
+      <div class="content">
+        <div class="method-tabs">
+          <div class="method-tab"><i class="ti ti-scan" aria-hidden="true"></i>Scan</div>
+          <div class="method-tab active"><i class="ti ti-microphone" aria-hidden="true"></i>Voice</div>
+          <div class="method-tab"><i class="ti ti-pencil" aria-hidden="true"></i>Manual</div>
+        </div>
+        <p class="section-label">Heard 4 items — confirm to add</p>
+        <div class="voice-parsed">
+          <div class="parsed-row">
+            <div class="parsed-name"><i class="ti ti-circle-check" aria-hidden="true"></i> Eggs</div>
+            <div class="parsed-qty">6 pcs</div>
+          </div>
+          <div class="parsed-row">
+            <div class="parsed-name"><i class="ti ti-circle-check" aria-hidden="true"></i> Rice</div>
+            <div class="parsed-qty">500 g</div>
+          </div>
+          <div class="parsed-row">
+            <div class="parsed-name"><i class="ti ti-circle-check" aria-hidden="true"></i> Onions</div>
+            <div class="parsed-qty">2 pcs</div>
+          </div>
+          <div class="parsed-row">
+            <div class="parsed-name"><i class="ti ti-circle-check" aria-hidden="true"></i> Milk</div>
+            <div class="parsed-qty">1 L</div>
+          </div>
+        </div>
+        <div style="display:flex;gap:10px">
+          <button style="flex:1;background:var(--card-bg);border:0.5px solid var(--border);border-radius:14px;padding:13px;font-size:14px;font-weight:500;color:var(--color-text-primary);display:flex;align-items:center;justify-content:center;gap:7px">
+            <i class="ti ti-microphone" aria-hidden="true" style="font-size:16px"></i> Redo
+          </button>
+          <button class="voice-add-btn" style="flex:2">
+            <i class="ti ti-circle-plus" aria-hidden="true" style="font-size:16px"></i> Add all to pantry
+          </button>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADD SCREEN — MANUAL TAB (autosuggest open) -->
+  <div class="screen-wrap">
+    <p class="screen-label">Add item — Manual (autosuggest)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="fs-nav">
+        <div class="back-btn"><i class="ti ti-arrow-left" aria-hidden="true" style="font-size:18px"></i> Pantry</div>
+        <h1>Add item</h1>
+        <div class="spacer"></div>
+      </div>
+      <div class="content">
+        <div class="method-tabs">
+          <div class="method-tab"><i class="ti ti-scan" aria-hidden="true"></i>Scan</div>
+          <div class="method-tab"><i class="ti ti-microphone" aria-hidden="true"></i>Voice</div>
+          <div class="method-tab active"><i class="ti ti-pencil" aria-hidden="true"></i>Manual</div>
+        </div>
+        <div class="form-field">
+          <label class="form-label">Ingredient name</label>
+          <div class="form-input" style="border-color: var(--primary);">
+            <span style="color:var(--color-text-primary)">Chick</span>
+            <i class="ti ti-x" aria-hidden="true" style="font-size:16px;color:var(--color-text-secondary)"></i>
+          </div>
+          <div class="autosuggest-list">
+            <div class="suggest-row" style="background:#FAF0EF">
+              <div class="suggest-icon"></div>
+              <div><div class="suggest-name" style="color:var(--primary);font-weight:500">Chicken breast</div><div class="suggest-cat">Protein</div></div>
+            </div>
+            <div class="suggest-row">
+              <div class="suggest-icon"></div>
+              <div><div class="suggest-name">Chickpeas</div><div class="suggest-cat">Legumes</div></div>
+            </div>
+            <div class="suggest-row">
+              <div class="suggest-icon"></div>
+              <div><div class="suggest-name">Chicken thighs</div><div class="suggest-cat">Protein</div></div>
+            </div>
+          </div>
+        </div>
+        <div class="page-bottom"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ADD SCREEN — MANUAL TAB (item selected, unit auto-filled) -->
+  <div class="screen-wrap">
+    <p class="screen-label">Add item — Manual (item selected)</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="fs-nav">
+        <div class="back-btn"><i class="ti ti-arrow-left" aria-hidden="true" style="font-size:18px"></i> Pantry</div>
+        <h1>Add item</h1>
+        <div class="spacer"></div>
+      </div>
+      <div class="content">
+        <div class="method-tabs">
+          <div class="method-tab"><i class="ti ti-scan" aria-hidden="true"></i>Scan</div>
+          <div class="method-tab"><i class="ti ti-microphone" aria-hidden="true"></i>Voice</div>
+          <div class="method-tab active"><i class="ti ti-pencil" aria-hidden="true"></i>Manual</div>
+        </div>
+        <div class="form-field">
+          <label class="form-label">Ingredient name</label>
+          <div class="form-input" style="background:#FAF0EF;border-color:var(--primary)">
+            <span style="color:var(--color-text-primary);font-weight:500">Chicken breast</span>
+            <i class="ti ti-circle-check" aria-hidden="true" style="font-size:16px;color:var(--primary)"></i>
+          </div>
+        </div>
+        <div class="qty-unit-row">
+          <div class="form-field">
+            <label class="form-label">Quantity</label>
+            <div class="form-input"><span style="color:var(--color-text-primary)">500</span></div>
+          </div>
+          <div class="form-field">
+            <label class="form-label">Unit</label>
+            <div class="unit-selector">
+              <span>g <span class="unit-auto-badge">Auto</span></span>
+              <i class="ti ti-chevron-down" aria-hidden="true" style="font-size:15px;color:var(--color-text-secondary)"></i>
+            </div>
+          </div>
+        </div>
+        <div class="form-field">
+          <label class="form-label">Category</label>
+          <div class="cat-selector">
+            <div class="cat-chip">Produce</div>
+            <div class="cat-chip active">Protein</div>
+            <div class="cat-chip">Dairy</div>
+            <div class="cat-chip">Grains</div>
+            <div class="cat-chip">Other</div>
+          </div>
+        </div>
+        <button class="add-item-btn">
+          <i class="ti ti-circle-plus" aria-hidden="true" style="font-size:16px"></i> Add to pantry
+        </button>
+        <div class="page-bottom"></div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/docs/saved_and_profile_v2.html
+++ b/docs/saved_and_profile_v2.html
@@ -1,0 +1,324 @@
+
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  :root {
+    --primary: #D75A4A; --primary-dark: #D24735; --primary-light: #E08074;
+    --secondary: #A8B39A; --app-bg: #FAF9F6; --card-bg: #FFFFFF;
+    --border: rgba(0,0,0,0.1); --tab-h: 64px;
+  }
+  .wf-root { display:flex; flex-direction:column; align-items:center; padding:1.5rem 0.5rem; gap:3rem; font-family:var(--font-sans,sans-serif); }
+  .screen-wrap { display:flex; flex-direction:column; align-items:center; gap:8px; }
+  .screen-label { font-size:11px; font-weight:500; letter-spacing:0.08em; text-transform:uppercase; color:var(--color-text-secondary); text-align:center; }
+  .phone { width:320px; background:var(--app-bg); border-radius:28px; border:1.5px solid rgba(0,0,0,0.13); overflow:hidden; display:flex; flex-direction:column; }
+  .status-bar { display:flex; justify-content:space-between; align-items:center; padding:10px 20px 4px; font-size:11px; color:var(--color-text-secondary); }
+  .top-nav { padding:4px 16px 12px; display:flex; align-items:center; justify-content:space-between; }
+  .top-nav h1 { font-size:22px; font-weight:500; color:var(--color-text-primary); }
+  .content { flex:1; padding:0 14px; display:flex; flex-direction:column; gap:14px; }
+  .section-label { font-size:11px; font-weight:500; letter-spacing:0.07em; text-transform:uppercase; color:var(--color-text-secondary); margin-bottom:-4px; }
+  .card { background:var(--card-bg); border-radius:16px; border:0.5px solid var(--border); padding:14px; }
+  .divider { height:0.5px; background:var(--border); }
+  .page-bottom { height:10px; }
+  .tab-bar { height:var(--tab-h); background:var(--card-bg); border-top:0.5px solid var(--border); display:flex; align-items:center; justify-content:space-around; padding:0 8px; flex-shrink:0; }
+  .tab-item { display:flex; flex-direction:column; align-items:center; gap:3px; flex:1; font-size:10px; color:var(--color-text-secondary); padding:8px 0; }
+  .tab-item i { font-size:22px; }
+  .tab-item.active { color:var(--primary); }
+  .chips-row { display:flex; gap:7px; flex-wrap:wrap; }
+  .chip { border-radius:20px; padding:6px 14px; font-size:13px; border:0.5px solid var(--border); background:var(--card-bg); color:var(--color-text-secondary); }
+  .chip.active { background:var(--primary); color:white; border-color:var(--primary); }
+  .search-bar { display:flex; align-items:center; gap:8px; background:var(--card-bg); border:0.5px solid var(--border); border-radius:14px; padding:10px 14px; color:var(--color-text-secondary); font-size:13px; }
+
+  .recipe-card { background:var(--card-bg); border-radius:16px; border:0.5px solid var(--border); overflow:hidden; }
+  .recipe-card-main { display:flex; align-items:stretch; }
+  .recipe-thumb { width:80px; background:var(--secondary); opacity:0.25; flex-shrink:0; min-height:76px; }
+  .recipe-body { padding:10px 12px; flex:1; display:flex; flex-direction:column; gap:5px; }
+  .recipe-name { font-size:14px; font-weight:500; color:var(--color-text-primary); }
+  .recipe-meta { display:flex; gap:10px; font-size:11px; color:var(--color-text-secondary); align-items:center; }
+  .recipe-meta i { font-size:13px; }
+  .recipe-tags { display:flex; gap:5px; flex-wrap:wrap; }
+  .r-tag { font-size:10px; background:#FAF0EF; color:#A32D2D; border-radius:6px; padding:2px 7px; }
+  .r-tag-chef { font-size:10px; background:#FAF0EF; color:#A32D2D; border-radius:6px; padding:2px 7px; display:flex; align-items:center; gap:3px; }
+  .match-bar-wrap { padding:8px 12px 10px; border-top:0.5px solid var(--border); display:flex; align-items:center; gap:8px; }
+  .match-bar-bg { flex:1; height:5px; background:#F0F0ED; border-radius:3px; overflow:hidden; }
+  .match-bar-fill { height:100%; border-radius:3px; background:var(--secondary); }
+  .match-bar-fill.high { background:#639922; }
+  .match-bar-fill.mid { background:var(--secondary); }
+  .match-bar-fill.low { background:#BA7517; }
+  .match-pct { font-size:11px; font-weight:500; color:var(--color-text-secondary); white-space:nowrap; }
+  .match-pct.high { color:#3B6D11; }
+  .match-pct.mid { color:#5F5E5A; }
+  .match-pct.low { color:#854F0B; }
+
+  .expanded-recipe { background:var(--card-bg); border-radius:16px; border:2px solid var(--primary); overflow:hidden; }
+  .expanded-header { background:var(--primary); padding:14px; color:white; }
+  .expanded-title { font-size:16px; font-weight:500; margin-bottom:5px; }
+  .expanded-meta { display:flex; gap:12px; font-size:12px; opacity:0.85; }
+  .expanded-meta-item { display:flex; align-items:center; gap:4px; }
+  .expanded-meta-item i { font-size:13px; }
+  .expanded-body { padding:12px 14px; display:flex; flex-direction:column; gap:12px; }
+  .ing-row-sm { display:flex; justify-content:space-between; align-items:center; padding:7px 0; border-bottom:0.5px solid var(--border); font-size:12px; }
+  .ing-row-sm:last-child { border-bottom:none; }
+  .ing-left { display:flex; align-items:center; gap:6px; color:var(--color-text-primary); }
+  .ing-left i { font-size:13px; }
+  .ing-right-sm { display:flex; align-items:center; gap:6px; }
+  .ing-qty-sm { color:var(--color-text-secondary); }
+  .tag-pantry-sm { font-size:10px; color:#3B6D11; background:#EAF3DE; border-radius:5px; padding:2px 6px; }
+  .tag-missing-sm { font-size:10px; color:#854F0B; background:#FAEEDA; border-radius:5px; padding:2px 6px; }
+  .step-row-sm { display:flex; gap:9px; align-items:flex-start; }
+  .step-num-sm { width:20px; height:20px; border-radius:50%; background:#FAF0EF; color:#A32D2D; font-size:11px; font-weight:500; display:flex; align-items:center; justify-content:center; flex-shrink:0; margin-top:1px; }
+  .step-text-sm { font-size:12px; color:var(--color-text-primary); line-height:1.5; }
+  .expanded-cta-row { display:flex; gap:8px; }
+  .btn-cook { flex:2; background:var(--primary); color:white; border:none; border-radius:12px; padding:11px; font-size:13px; font-weight:500; display:flex; align-items:center; justify-content:center; gap:6px; }
+  .btn-delete { flex:1; background:var(--card-bg); color:#A32D2D; border:0.5px solid rgba(210,71,53,0.3); border-radius:12px; padding:11px; font-size:13px; font-weight:500; display:flex; align-items:center; justify-content:center; gap:6px; }
+  .chef-badge-sm { font-size:10px; background:#FAF0EF; color:#A32D2D; border-radius:20px; padding:2px 8px; display:inline-flex; align-items:center; gap:3px; }
+
+  .profile-header { display:flex; flex-direction:column; align-items:center; gap:8px; padding:4px 0 8px; }
+  .avatar { width:68px; height:68px; border-radius:50%; background:var(--secondary); opacity:0.4; border:3px solid #E08074; }
+  .profile-name { font-size:17px; font-weight:500; color:var(--color-text-primary); }
+  .profile-sub { font-size:12px; color:var(--color-text-secondary); }
+  .profile-stats { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+  .p-stat { background:var(--card-bg); border-radius:12px; border:0.5px solid var(--border); padding:10px 8px; text-align:center; }
+  .p-val { font-size:18px; font-weight:500; color:var(--primary); }
+  .p-lbl { font-size:10px; color:var(--color-text-secondary); margin-top:2px; }
+  .pref-row { display:flex; align-items:center; justify-content:space-between; padding:11px 0; }
+  .pref-row+.pref-row { border-top:0.5px solid var(--border); }
+  .pref-left { display:flex; align-items:center; gap:10px; font-size:13px; color:var(--color-text-primary); }
+  .pref-left i { font-size:17px; color:var(--color-text-secondary); }
+  .toggle { width:36px; height:20px; border-radius:10px; background:#D3D1C7; position:relative; flex-shrink:0; }
+  .toggle.on { background:var(--primary); }
+  .toggle::after { content:''; position:absolute; width:14px; height:14px; background:white; border-radius:50%; top:3px; left:3px; }
+  .toggle.on::after { left:19px; }
+  .chef-influence-note { display:flex; align-items:flex-start; gap:7px; background:#FAF0EF; border-radius:10px; padding:9px 11px; font-size:11px; color:#712B13; line-height:1.5; }
+  .chef-influence-note i { font-size:14px; color:var(--primary); flex-shrink:0; margin-top:1px; }
+  .pref-arrow { color:var(--color-text-secondary); font-size:16px; }
+  .danger-row { color:#A32D2D; }
+  .danger-row i { color:#A32D2D !important; }
+</style>
+
+<div class="wf-root">
+
+  <!-- SAVED — COLLAPSED LIST -->
+  <div class="screen-wrap">
+    <p class="screen-label">Saved — List view</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Saved recipes</h1>
+        <div style="font-size:12px;color:var(--color-text-secondary)">8 recipes</div>
+      </div>
+      <div class="content">
+        <div class="search-bar"><i class="ti ti-search" aria-hidden="true"></i><span>Search saved recipes…</span></div>
+        <div class="chips-row">
+          <div class="chip active">All</div>
+          <div class="chip">Breakfast</div>
+          <div class="chip">Lunch</div>
+          <div class="chip">Dinner</div>
+          <div class="chip">Chef picks</div>
+        </div>
+
+        <div class="recipe-card">
+          <div class="recipe-card-main">
+            <div class="recipe-thumb"></div>
+            <div class="recipe-body">
+              <div class="recipe-name">Spiced Tomato &amp; Feta Shakshuka</div>
+              <div class="recipe-meta"><i class="ti ti-clock" aria-hidden="true"></i>30 min<i class="ti ti-chef-hat" aria-hidden="true" style="margin-left:4px"></i>Easy</div>
+              <div class="recipe-tags">
+                <span class="r-tag">Dinner</span>
+                <span class="r-tag-chef"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:10px"></i>Chef</span>
+              </div>
+            </div>
+          </div>
+          <div class="match-bar-wrap">
+            <div class="match-bar-bg"><div class="match-bar-fill high" style="width:94%"></div></div>
+            <span class="match-pct high">94% in pantry</span>
+          </div>
+        </div>
+
+        <div class="recipe-card">
+          <div class="recipe-card-main">
+            <div class="recipe-thumb"></div>
+            <div class="recipe-body">
+              <div class="recipe-name">Avocado &amp; Poached Egg Toast</div>
+              <div class="recipe-meta"><i class="ti ti-clock" aria-hidden="true"></i>10 min<i class="ti ti-chef-hat" aria-hidden="true" style="margin-left:4px"></i>Easy</div>
+              <div class="recipe-tags"><span class="r-tag">Breakfast</span></div>
+            </div>
+          </div>
+          <div class="match-bar-wrap">
+            <div class="match-bar-bg"><div class="match-bar-fill mid" style="width:60%"></div></div>
+            <span class="match-pct mid">60% in pantry</span>
+          </div>
+        </div>
+
+        <div class="recipe-card">
+          <div class="recipe-card-main">
+            <div class="recipe-thumb"></div>
+            <div class="recipe-body">
+              <div class="recipe-name">Lemon Garlic Pasta</div>
+              <div class="recipe-meta"><i class="ti ti-clock" aria-hidden="true"></i>20 min<i class="ti ti-chef-hat" aria-hidden="true" style="margin-left:4px"></i>Easy</div>
+              <div class="recipe-tags">
+                <span class="r-tag">Lunch</span>
+                <span class="r-tag-chef"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:10px"></i>Chef</span>
+              </div>
+            </div>
+          </div>
+          <div class="match-bar-wrap">
+            <div class="match-bar-bg"><div class="match-bar-fill low" style="width:40%"></div></div>
+            <span class="match-pct low">40% in pantry</span>
+          </div>
+        </div>
+
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item active"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- SAVED — EXPANDED CARD -->
+  <div class="screen-wrap">
+    <p class="screen-label">Saved — Expanded recipe card</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Saved recipes</h1>
+        <div style="font-size:12px;color:var(--color-text-secondary)">8 recipes</div>
+      </div>
+      <div class="content">
+        <div class="search-bar"><i class="ti ti-search" aria-hidden="true"></i><span>Search saved recipes…</span></div>
+        <div class="chips-row">
+          <div class="chip active">All</div>
+          <div class="chip">Breakfast</div>
+          <div class="chip">Lunch</div>
+          <div class="chip">Dinner</div>
+          <div class="chip">Chef picks</div>
+        </div>
+
+        <div class="expanded-recipe">
+          <div class="expanded-header">
+            <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:8px">
+              <div class="expanded-title">Spiced Tomato &amp; Feta Shakshuka</div>
+              <span class="chef-badge-sm"><i class="ti ti-sparkles" aria-hidden="true" style="font-size:10px"></i>Chef</span>
+            </div>
+            <div class="expanded-meta">
+              <div class="expanded-meta-item"><i class="ti ti-clock" aria-hidden="true"></i>30 min</div>
+              <div class="expanded-meta-item"><i class="ti ti-chef-hat" aria-hidden="true"></i>Easy</div>
+              <div class="expanded-meta-item"><i class="ti ti-users" aria-hidden="true"></i>2 servings</div>
+            </div>
+          </div>
+          <div class="match-bar-wrap" style="border-top:none;padding-top:10px">
+            <div class="match-bar-bg"><div class="match-bar-fill high" style="width:94%"></div></div>
+            <span class="match-pct high">94% in pantry</span>
+          </div>
+          <div class="expanded-body">
+            <p class="section-label">Ingredients</p>
+            <div style="background:var(--app-bg);border-radius:12px;padding:2px 10px;">
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Tomatoes</div><div class="ing-right-sm"><span class="ing-qty-sm">3 pcs</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Eggs</div><div class="ing-right-sm"><span class="ing-qty-sm">4 pcs</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-circle-check" aria-hidden="true" style="color:#3B6D11"></i>Feta cheese</div><div class="ing-right-sm"><span class="ing-qty-sm">80 g</span><span class="tag-pantry-sm">In pantry</span></div></div>
+              <div class="ing-row-sm"><div class="ing-left"><i class="ti ti-alert-circle" aria-hidden="true" style="color:#BA7517"></i>Cumin</div><div class="ing-right-sm"><span class="ing-qty-sm">1 tsp</span><span class="tag-missing-sm">Missing</span></div></div>
+            </div>
+            <p class="section-label">Steps</p>
+            <div style="display:flex;flex-direction:column;gap:9px">
+              <div class="step-row-sm"><div class="step-num-sm">1</div><div class="step-text-sm">Heat olive oil. Sauté garlic and onion until soft, about 4 minutes.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">2</div><div class="step-text-sm">Add tomatoes and spices. Simmer 10 min until thickened.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">3</div><div class="step-text-sm">Create wells, crack eggs in. Cover and cook 5–7 min.</div></div>
+              <div class="step-row-sm"><div class="step-num-sm">4</div><div class="step-text-sm">Crumble feta on top and serve straight from the pan.</div></div>
+            </div>
+            <div class="expanded-cta-row">
+              <button class="btn-cook"><i class="ti ti-chef-hat" aria-hidden="true" style="font-size:15px"></i> Cook this</button>
+              <button class="btn-delete"><i class="ti ti-trash" aria-hidden="true" style="font-size:15px"></i> Delete</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item active"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROFILE -->
+  <div class="screen-wrap">
+    <p class="screen-label">Profile</p>
+    <div class="phone">
+      <div class="status-bar"><span>9:41</span><span><i class="ti ti-wifi" aria-hidden="true"></i> <i class="ti ti-battery" aria-hidden="true"></i></span></div>
+      <div class="top-nav">
+        <h1>Profile</h1>
+        <div style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--color-text-secondary)"><i class="ti ti-settings" aria-hidden="true" style="font-size:20px"></i></div>
+      </div>
+      <div class="content">
+
+        <div class="profile-header">
+          <div class="avatar"></div>
+          <div class="profile-name">Jamie Moreau</div>
+          <div class="profile-sub">Home cook · Montréal</div>
+        </div>
+
+        <div class="profile-stats">
+          <div class="p-stat"><div class="p-val">8</div><div class="p-lbl">Saved</div></div>
+          <div class="p-stat"><div class="p-val">14</div><div class="p-lbl">Pantry items</div></div>
+          <div class="p-stat"><div class="p-val">23</div><div class="p-lbl">Cooked</div></div>
+        </div>
+
+        <p class="section-label">Dietary preferences</p>
+        <div class="chef-influence-note">
+          <i class="ti ti-sparkles" aria-hidden="true"></i>
+          <span>Chef uses these automatically. You can override them per generation on the Chef screen.</span>
+        </div>
+        <div class="card" style="padding:2px 14px;">
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-leaf" aria-hidden="true"></i>Vegetarian</div>
+            <div class="toggle"></div>
+          </div>
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-wheat" aria-hidden="true"></i>Gluten-free</div>
+            <div class="toggle"></div>
+          </div>
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-barbell" aria-hidden="true"></i>High protein</div>
+            <div class="toggle on"></div>
+          </div>
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-heart" aria-hidden="true"></i>Macro tracking</div>
+            <div class="toggle on"></div>
+          </div>
+        </div>
+
+        <p class="section-label">Account</p>
+        <div class="card" style="padding:2px 14px;">
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-user" aria-hidden="true"></i>Edit profile</div>
+            <i class="ti ti-chevron-right pref-arrow" aria-hidden="true"></i>
+          </div>
+          <div class="pref-row">
+            <div class="pref-left"><i class="ti ti-bell" aria-hidden="true"></i>Notifications</div>
+            <i class="ti ti-chevron-right pref-arrow" aria-hidden="true"></i>
+          </div>
+          <div class="pref-row danger-row">
+            <div class="pref-left danger-row"><i class="ti ti-logout" aria-hidden="true"></i>Log out</div>
+          </div>
+        </div>
+
+        <div class="page-bottom"></div>
+      </div>
+      <div class="tab-bar">
+        <div class="tab-item"><i class="ti ti-home" aria-hidden="true"></i><span>Home</span></div>
+        <div class="tab-item"><i class="ti ti-sparkles" aria-hidden="true"></i><span>Chef</span></div>
+        <div class="tab-item"><i class="ti ti-basket" aria-hidden="true"></i><span>Pantry</span></div>
+        <div class="tab-item"><i class="ti ti-bookmark" aria-hidden="true"></i><span>Saved</span></div>
+        <div class="tab-item active"><i class="ti ti-user" aria-hidden="true"></i><span>Profile</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary

- **Design tokens** — `apps/web/src/styles/tokens.css` with all CSS custom properties (colors, spacing, radii, typography); zero hardcoded hex values in any component file
- **`components.css`** — ~500 lines covering every class used across all six pages and five shared components, built entirely from tokens
- **Shared components** — `MatchBar` (color-threshold fill), `PantryTag` (In pantry / Missing), `Toast` (auto-dismiss, 3 s), `RecipeCard` (collapsed + expanded), auth-aware `TabBar` (Profile ↔ Sign in, hidden on /auth)
- **Six full static screens** backed by `src/data/fakeData.js` — no API calls yet:
  - **Home** — hero card, stats row, recipe suggestions; 3 states (default / card expanded / post-cook toast)
  - **Chef** — state machine `input → generating → result`; chip selectors, servings stepper, missing-ingredient banner, Approve / Retry
  - **Pantry** — ingredient grid grouped by category + Add Item full-screen flow with Scan / Voice / Manual tabs
  - **Saved** — search + filter chips, collapsed and expanded recipe cards with Cook / Delete
  - **Profile** — dietary preference toggles (`role="switch"`), stats row, account list rows
  - **Auth** — sign-in / sign-up modes, client-side validation (email format, password ≥ 8 chars, confirm match), Google SSO stub, "Maybe later" skip

## Test plan

- [ ] `npm run build -w @plated/web` — passes clean (verified: 597 ms, 30 KB CSS)
- [ ] `npm run dev` — navigate to each tab, all screens render without console errors
- [ ] **Chef**: tap "Chef it" → spinner 1.8 s → result with ingredient list; Approve → toast → back to input form
- [ ] **Pantry**: tap + FAB → Add Item screen; switch Scan / Voice / Manual tabs; Voice: tap mic → listening animation → parsed list
- [ ] **Saved**: type in search, switch filter chips, expand a card, tap Cook (toast) or Delete (removes card)
- [ ] **Auth**: toggle sign-in ↔ sign-up; submit empty → inline field errors; valid submit → alert stub; "Maybe later" → Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)