### PR TITLE
fix(deploy): Vercel config for monorepo + SPA routing

### DIFF
--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: process.env.PORT ? Number(process.env.PORT) : 5173,
     proxy: {
       // Proxy API calls in development so CORS isn't needed
       '/api': {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build -w @plated/web",
+  "outputDirectory": "apps/web/dist",
+  "installCommand": "npm install",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Problem

The deployed Vercel preview had broken CSS and blank screens because:
1. No `vercel.json` — Vercel couldn't find the build output in the monorepo (`apps/web/dist/`) and was likely serving the wrong directory
2. No SPA rewrite rule — navigating to any route other than `/` returned a 404 instead of `index.html`

## Changes

- **`vercel.json`** — tells Vercel:
  - Build command: `npm run build -w @plated/web`
  - Output directory: `apps/web/dist`
  - Rewrite all paths to `/index.html` (required for React Router SPA)
- **`apps/web/vite.config.js`** — reads `PORT` from env so the dev server works with dynamic port assignment

## Test plan

- [ ] Merge → Vercel redeploys → open the deployment URL and confirm CSS loads
- [ ] Navigate directly to `/chef`, `/pantry`, `/saved` — should render (not 404)
- [ ] Check on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)