### PR TITLE
fix(ui): align deployed app styles with wireframes

### DIFF
--- a/apps/web/src/pages/Home.jsx
+++ b/apps/web/src/pages/Home.jsx
@@ -63,13 +63,13 @@ export default function Home() {
       <div className="stats-row">
         <div className="stat-card">
           <BasketIcon className="stat-card__icon" aria-hidden="true" />
-          <span className="stat-card__value">{stats.pantryCount}</span>
-          <span className="stat-card__label">Pantry items</span>
+          <span className="stat-card__val">{stats.pantryCount}</span>
+          <span className="stat-card__lbl">Pantry items</span>
         </div>
         <div className="stat-card">
           <BookmarkIcon className="stat-card__icon" aria-hidden="true" />
-          <span className="stat-card__value">{stats.savedCount}</span>
-          <span className="stat-card__label">Saved recipes</span>
+          <span className="stat-card__val">{stats.savedCount}</span>
+          <span className="stat-card__lbl">Saved recipes</span>
         </div>
       </div>
 

--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -68,9 +68,8 @@ svg { display: block; flex-shrink: 0; }
 
 .page-title {
   font-size: var(--text-2xl);
-  font-weight: 700;
+  font-weight: 500;
   color: var(--color-text-primary);
-  letter-spacing: -0.3px;
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -178,6 +177,11 @@ svg { display: block; flex-shrink: 0; }
   height: 1px;
   background: var(--color-border);
   margin: var(--space-6) 0;
+}
+
+/* No extra margin when divider is inside the suggestion list card */
+.suggestion-list .divider {
+  margin: 0;
 }
 
 /* ── Buttons ────────────────────────────────────────────────────────────────── */
@@ -341,12 +345,14 @@ svg { display: block; flex-shrink: 0; }
 
 .match-bar-wrap {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
 }
 
 .match-bar-track {
-  height: 6px;
+  flex: 1;
+  height: 5px;
   border-radius: var(--radius-full);
   background: var(--color-border);
   overflow: hidden;
@@ -363,8 +369,9 @@ svg { display: block; flex-shrink: 0; }
 .match-bar-fill--low  { background: var(--color-match-low-bar); }
 
 .match-bar-label {
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .match-bar-fill--high + .match-bar-label,
@@ -374,10 +381,10 @@ svg { display: block; flex-shrink: 0; }
 .match-bar-fill--low  + .match-bar-label,
 .match-bar-wrap .match-bar-label--low  { color: var(--color-match-low-text); }
 
-/* compact versions used in recipe cards */
-.recipe-card__match-bar,
-.expanded-recipe__match-bar {
-  margin-top: var(--space-2);
+/* match bar in collapsed Saved cards — sits below main content with border-top */
+.recipe-card > .match-bar-wrap {
+  padding: 8px var(--space-4) var(--space-3);
+  border-top: 1px solid var(--color-border);
 }
 
 /* ── Pantry tag ──────────────────────────────────────────────────────────────── */
@@ -716,6 +723,36 @@ svg { display: block; flex-shrink: 0; }
   margin-bottom: var(--space-6);
 }
 
+.hero-card__title {
+  font-size: 17px;
+  font-weight: 500;
+  color: white;
+  margin-bottom: 4px;
+}
+
+.hero-card__body {
+  font-size: var(--text-base);
+  color: white;
+  opacity: 0.85;
+  margin-bottom: 14px;
+}
+
+.hero-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: white;
+  color: var(--color-primary-text);
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 9px 18px;
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.hero-card__cta svg { width: 15px; height: 15px; }
+
 .hero-card__eyebrow {
   font-size: var(--text-xs);
   font-weight: 600;
@@ -747,7 +784,7 @@ svg { display: block; flex-shrink: 0; }
 
 .stats-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--space-3);
   margin-bottom: var(--space-6);
 }
@@ -760,14 +797,27 @@ svg { display: block; flex-shrink: 0; }
   text-align: center;
 }
 
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.stat-card__icon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-secondary);
+  margin-bottom: 2px;
+}
+
 .stat-card__val {
   font-size: var(--text-2xl);
-  font-weight: 700;
+  font-weight: 500;
   color: var(--color-text-primary);
 }
 
 .stat-card__lbl {
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   color: var(--color-text-secondary);
   font-weight: 500;
   margin-top: 2px;
@@ -777,9 +827,9 @@ svg { display: block; flex-shrink: 0; }
 
 .recipe-card {
   background: var(--color-surface);
-  border-radius: var(--radius-xl);
+  border-radius: var(--radius-2xl);
   border: 1px solid var(--color-border);
-  padding: var(--space-4);
+  overflow: hidden;
   margin-bottom: var(--space-3);
   cursor: pointer;
   transition: box-shadow var(--transition-fast);
@@ -789,19 +839,22 @@ svg { display: block; flex-shrink: 0; }
 
 .recipe-card__main {
   display: flex;
-  gap: var(--space-3);
+  gap: 0;
 }
 
 .recipe-card__thumb {
-  width: 56px;
-  height: 56px;
-  border-radius: var(--radius-md);
+  width: 80px;
   background: var(--color-secondary);
   flex-shrink: 0;
-  opacity: 0.35;
+  opacity: 0.25;
+  min-height: 76px;
 }
 
-.recipe-card__body { flex: 1; min-width: 0; }
+.recipe-card__body {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-3) var(--space-4);
+}
 
 .recipe-card__name {
   font-size: var(--text-md);
@@ -856,17 +909,163 @@ svg { display: block; flex-shrink: 0; }
 /* ── Suggestion list (home) ──────────────────────────────────────────────────── */
 
 .suggestion-list {
+  background: var(--color-surface);
+  border-radius: var(--radius-2xl);
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+}
+
+/* Collapsed row inside suggestion-list */
+.recipe-card__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.recipe-card__row:hover { background: var(--color-bg); }
+
+.recipe-card__info { flex: 1; min-width: 0; }
+
+.recipe-card__match-pill {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--color-match-high-bg);
+  color: var(--color-match-high-text);
+  border-radius: var(--radius-sm);
+  padding: 3px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── RecipeCard expanded (Home inline) ───────────────────────────────────────── */
+
+.recipe-card--expanded {
+  background: var(--color-surface);
+  border-radius: var(--radius-2xl);
+  border: 2px solid var(--color-primary);
+  overflow: hidden;
+}
+
+.recipe-card__expanded-header {
+  width: 100%;
+  text-align: left;
+  background: var(--color-primary);
+  border: none;
+  padding: var(--space-4);
+  cursor: pointer;
+}
+
+.recipe-card__expanded-title {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  color: white;
+  margin-bottom: 5px;
+}
+
+.recipe-card__expanded-meta {
+  display: flex;
+  gap: var(--space-4);
+  font-size: var(--text-sm);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.recipe-card__expanded-meta span { display: flex; align-items: center; gap: 4px; }
+.recipe-card__expanded-meta svg { width: 13px; height: 13px; }
+
+.recipe-card__match-bar {
+  padding: 8px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.recipe-card__expanded-body {
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
+  gap: var(--space-3);
+}
+
+.recipe-card__ing-list {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.recipe-card__ing-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--text-sm);
+}
+
+.recipe-card__ing-row:last-child { border-bottom: none; }
+
+.recipe-card__ing-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-primary);
+}
+
+.recipe-card__ing-left svg { width: 13px; height: 13px; }
+
+.recipe-card__ing-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.recipe-card__ing-qty {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.recipe-card__steps { display: flex; flex-direction: column; gap: var(--space-2); }
+
+.recipe-card__step-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.recipe-card__step-num {
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary-bg);
+  color: var(--color-primary-text);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.recipe-card__step-text {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+
+.recipe-card__cta-row {
+  display: flex;
   gap: var(--space-2);
 }
+
+.recipe-card__cta-btn { flex: 1; border-radius: var(--radius-lg); padding: 12px; }
 
 /* ── Expanded recipe (Saved) ─────────────────────────────────────────────────── */
 
 .expanded-recipe {
   background: var(--color-surface);
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2xl);
+  border: 2px solid var(--color-primary);
   margin-bottom: var(--space-3);
   overflow: hidden;
 }
@@ -876,21 +1075,22 @@ svg { display: block; flex-shrink: 0; }
   text-align: left;
   padding: var(--space-4);
   cursor: pointer;
-  background: none;
+  background: var(--color-primary);
   border: none;
 }
 
 .expanded-recipe__title-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: space-between;
   gap: var(--space-2);
-  margin-bottom: 4px;
+  margin-bottom: 5px;
 }
 
 .expanded-recipe__title {
   font-size: var(--text-lg);
-  font-weight: 700;
-  color: var(--color-text-primary);
+  font-weight: 500;
+  color: white;
 }
 
 .chef-badge {
@@ -900,9 +1100,11 @@ svg { display: block; flex-shrink: 0; }
   padding: 2px 8px;
   border-radius: var(--radius-full);
   font-size: var(--text-2xs);
-  font-weight: 700;
-  background: var(--color-primary-bg);
-  color: var(--color-primary-text);
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .chef-badge svg { width: 10px; height: 10px; }
@@ -911,14 +1113,22 @@ svg { display: block; flex-shrink: 0; }
   display: flex;
   gap: var(--space-4);
   font-size: var(--text-sm);
-  color: var(--color-text-secondary);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .expanded-recipe__meta span { display: flex; align-items: center; gap: 4px; }
 .expanded-recipe__meta svg { width: 12px; height: 12px; }
 
+.expanded-recipe__match-bar {
+  padding: 8px var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
 .expanded-recipe__body {
-  padding: 0 var(--space-4) var(--space-4);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .expanded-cta-row {
@@ -1065,25 +1275,25 @@ svg { display: block; flex-shrink: 0; }
 /* ── Result state ────────────────────────────────────────────────────────────── */
 
 .result-header {
-  background: var(--color-surface);
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--color-border);
-  padding: var(--space-4);
+  background: var(--color-primary);
+  border-radius: var(--radius-3xl);
+  padding: var(--space-6);
   margin-bottom: var(--space-3);
+  color: white;
 }
 
 .result-header__title {
   font-size: var(--text-xl);
-  font-weight: 700;
-  color: var(--color-text-primary);
-  margin-bottom: var(--space-2);
+  font-weight: 500;
+  color: white;
+  margin-bottom: 6px;
 }
 
 .result-header__meta {
   display: flex;
   gap: var(--space-4);
   font-size: var(--text-sm);
-  color: var(--color-text-secondary);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .result-header__meta span { display: flex; align-items: center; gap: 4px; }


### PR DESCRIPTION
## Summary

- Hero card child elements (`__title`, `__body`, `__cta`) were missing CSS classes — nothing styled
- `stats-row` was 3 columns; wireframe specifies 2
- `match-bar-wrap` was `flex-direction: column`; wireframe is horizontal (bar + label side-by-side)
- `result-header` on Chef screen had a white background; wireframe specifies coral/primary
- `expanded-recipe__header` on Saved screen had no background; wireframe specifies coral/primary
- `RecipeCard` component (used on Home) used a completely different set of CSS class names from what `components.css` defined — the entire expanded state was unstyled
- `Home.jsx` used `stat-card__value`/`__label` but CSS defines `__val`/`__lbl`

## What changed

**`apps/web/src/styles/components.css`**
- Added hero card child styles, stat-card icon, match bar horizontal layout, 2-col stats grid
- Added all `recipe-card__*` classes for the Home RecipeCard expanded and collapsed states
- Restyled `suggestion-list` as a single card container with internal dividers
- Fixed `result-header` and `expanded-recipe__header` to use coral background

**`apps/web/src/pages/Home.jsx`**
- Corrected `stat-card__value` → `__val` and `stat-card__label` → `__lbl` to match CSS

## Test plan

- [ ] Home: hero card renders coral with white CTA button; stat cards show icon + value + label; suggestion list shows 3 recipes in one bordered container with match pills
- [ ] Home: clicking a suggestion expands inline with coral header, ingredients, steps, Cook/Save CTAs
- [ ] Chef: input state looks correct; result state shows coral recipe header
- [ ] Saved: collapsed cards show thumbnail + tags + match bar; expanded card shows coral header with Chef badge
- [ ] Profile: avatar, 3-stat grid, toggles, account rows all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)