### PR TITLE
fix(layout): restore scroll and sticky tab bar

### DIFF
--- a/apps/web/src/styles/components.css
+++ b/apps/web/src/styles/components.css
@@ -39,10 +39,9 @@ svg { display: block; flex-shrink: 0; }
   margin: 0 auto;
   background: var(--color-bg);
   position: relative;
-  overflow: hidden;
 }
 
-.app-main {
+.app-content {
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;


### PR DESCRIPTION
## Summary

- Removed `overflow: hidden` from `.app-shell` — it was clipping all page content and making the app completely unscrollable
- Renamed `.app-main` → `.app-content` to match the class rendered by `App.jsx` — the `flex: 1; overflow-y: auto` scroll rules were never being applied because the class name was wrong

## Root cause

`App.jsx` renders `<main className="app-content">` but `components.css` only defined `.app-main`. As a result, the scrollable content area had no `flex: 1` or `overflow-y: auto`, and `overflow: hidden` on the parent shell clipped everything.

## What changed

**`apps/web/src/styles/components.css`**
- `.app-shell`: removed `overflow: hidden`
- `.app-main` → renamed to `.app-content`

## Test plan

- [ ] All pages scroll when content exceeds the viewport
- [ ] Tab bar stays pinned to the bottom on all screens
- [ ] No horizontal overflow / layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)