### PR TITLE
Fix Vercel deployment for npm workspaces monorepo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": "dist",
-  "installCommand": "npm install"
+  "buildCommand": "npm run build -w apps/web",
+  "outputDirectory": "apps/web/dist",
+  "installCommand": "npm install --include=dev"
 }


### PR DESCRIPTION
## Summary
- Updated `vercel.json` to use `npm install --include=dev` so devDependencies (including `vite`) are installed during Vercel builds
- Changed build command to `npm run build -w apps/web` to build only the frontend workspace instead of all workspaces
- Fixed output directory to `apps/web/dist` to match where Vite outputs the build

## Why
Vercel sets `NODE_ENV=production` during builds, causing `npm install` to skip devDependencies. This meant `vite` was never installed and the build failed with `vite: command not found`. Additionally, `vercel.json` was hardcoding the old commands and overriding any UI-level settings.

## Reviewer notes
No code changes — config file only. Safe to merge and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)